### PR TITLE
RabbitMQ permissions update (+ scriptal, + SAMU 78, BISOM configure rights for Bunny)

### DIFF
--- a/hub/rabbitmq/definitions.json
+++ b/hub/rabbitmq/definitions.json
@@ -154,6 +154,27 @@
       "arguments": {}
     },
     {
+      "name": "fr.health.scriptal.message",
+      "vhost": "/",
+      "durable": true,
+      "auto_delete": false,
+      "arguments": {}
+    },
+    {
+      "name": "fr.health.scriptal.info",
+      "vhost": "/",
+      "durable": true,
+      "auto_delete": false,
+      "arguments": {}
+    },
+    {
+      "name": "fr.health.scriptal.ack",
+      "vhost": "/",
+      "durable": true,
+      "auto_delete": false,
+      "arguments": {}
+    },
+    {
       "name": "fr.health.normandie.message",
       "vhost": "/",
       "durable": true,
@@ -655,6 +676,30 @@
     {
       "source": "distribution",
       "vhost": "/",
+      "destination": "fr.health.scriptal.message",
+      "destination_type": "queue",
+      "routing_key": "fr.health.scriptal.message",
+      "arguments": {}
+    },
+    {
+      "source": "distribution",
+      "vhost": "/",
+      "destination": "fr.health.scriptal.ack",
+      "destination_type": "queue",
+      "routing_key": "fr.health.scriptal.ack",
+      "arguments": {}
+    },
+    {
+      "source": "distribution",
+      "vhost": "/",
+      "destination": "fr.health.scriptal.info",
+      "destination_type": "queue",
+      "routing_key": "fr.health.scriptal.info",
+      "arguments": {}
+    },
+    {
+      "source": "distribution",
+      "vhost": "/",
       "destination": "fr.health.samu76A.message",
       "destination_type": "queue",
       "routing_key": "fr.health.samu76A.message",
@@ -1062,6 +1107,10 @@
       "tags": []
     },
     {
+      "name": "fr.health.scriptal",
+      "tags": []
+    },
+    {
       "name": "fr.health.normandie",
       "tags": []
     },
@@ -1155,6 +1204,13 @@
       "read": "^(fr.health.samu091.message|fr.health.samu091.info|fr.health.samu091.ack|fr.health.samu090.message|fr.health.samu090.info|fr.health.samu090.ack)$"
     },
     {
+      "user": "fr.health.scriptal",
+      "vhost": "/",
+      "configure": "",
+      "write": "hubsante",
+      "read": "^(fr.health.scriptal.message|fr.health.scriptal.info|fr.health.scriptal.ack)$"
+    },
+    {
       "user": "fr.health.normandie",
       "vhost": "/",
       "configure": "",
@@ -1245,6 +1301,13 @@
       "vhost": "/",
       "user": "fr.health.bisom",
       "write": "^(fr.health.samu091|fr.health.samu090)$",
+      "read": ""
+    },
+    {
+      "exchange": "hubsante",
+      "vhost": "/",
+      "user": "fr.health.scriptal",
+      "write": "^fr.health.scriptal$",
       "read": ""
     },
     {


### PR DESCRIPTION
ajout des permissions pour s780 :  

- user
- 3 files pour le clientId
- 3 bindings sur l'exchange distribution
- 1 bloc permissions pour le user (write : hub, read : clientId.*)
- 1 bloc topic_permissions sur l'exchange hubsante


On doit pouvoir laisser la PR ouverte pendant les deux jours, pour le cas où d'autres ajouts soient nécessaires au fur et à mesure de l'avancée du projectathon ?