### PR TITLE
add date in log pattern

### DIFF
--- a/hub/dispatcher/src/main/resources/logback.xml
+++ b/hub/dispatcher/src/main/resources/logback.xml
@@ -7,7 +7,7 @@
 
     <appender name="STDOUT" class="ConsoleAppender">
         <encoder class="PatternLayoutEncoder">
-            <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} -- %msg%n</pattern>
+            <pattern>%d{"yyyy-MM-dd HH:mm:ss.SSS"} %-5level %logger{36} -- %msg%n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
fix old bug : logs were missing the date (only time), which led to lack of clarity