### PR TITLE
Log level fine tuning

### DIFF
--- a/hub/dispatcher/src/main/resources/logback.xml
+++ b/hub/dispatcher/src/main/resources/logback.xml
@@ -11,11 +11,11 @@
         </encoder>
     </appender>
 
-    <!-- We log at WARN level only except for our own loggers -->
-    <root level="WARN">
+    <!-- We log at ERROR level only except for our own loggers -->
+    <root level="ERROR">
         <appender-ref ref="STDOUT" />
     </root>
-    <logger name="com.hubsante.hub" level="INFO" additivity="false">
+    <logger name="com.hubsante.hub" level="DEBUG" additivity="false">
         <appender-ref ref="STDOUT" />
     </logger>
 </configuration>


### PR DESCRIPTION
- lower our own packages logger to DEBUG
- and set the others to ERROR instead of WARN (to avoid other packages spamming while we already have logged the error...) 