### PR TITLE
Feature/Ajout conditionnel de keyword dans les messages envoyés en fonction de la version

### DIFF
--- a/web/lrm/client/composables/messageUtils.js
+++ b/web/lrm/client/composables/messageUtils.js
@@ -124,7 +124,7 @@ export function buildMessage (innerMessage, distributionKind = 'Report') {
   }
   const store = useMainStore()
   const message = JSON.parse(JSON.stringify(EDXL_ENVELOPE)) // Deep copy
-  if (/^1|2/.test(store.selectedVhost.modelVersion)) {
+  if (/^((1\.)|(2\.))/.test(store.selectedVhost.modelVersion)) {
     // We delete 'keyword' from 'descriptor' if the model version is 1.* or 2.*
     delete message.descriptor.keyword
   } else {


### PR DESCRIPTION
Correction (temporaire?) d'ajout de la propriete 'keyword' a l'enveloppe EDXL-DE pour ne pas l'effectuer dans le cas ou la version de la lib modeles correspondante au vhost selectionné est 1.0.0 ou 2.0.0