### PR TITLE
fix(lrm/server): display branches in selector only in admin mode

### DIFF
--- a/web/lrm/client/components/SourceSelector.vue
+++ b/web/lrm/client/components/SourceSelector.vue
@@ -45,7 +45,7 @@ onMounted(() => {
 
 const sources = computed(() => [
   ...new Set(store.vhostMap.map((vhost) => vhost.modelVersion)),
-  ...props.branchNames,
+  ...(store.isAdvanced ? props.branchNames : []),
 ]);
 
 const selectedSource = ref('');


### PR DESCRIPTION
Modification : affichage des branches disponibles sur le répo Modèle uniquement en mode admin.