### PR TITLE
Healthcheck workflow

### DIFF
--- a/.github/workflows/healthcheck-ci.yml
+++ b/.github/workflows/healthcheck-ci.yml
@@ -1,0 +1,57 @@
+name: Healthcheck CI
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "tools/healthcheck/**"
+
+  pull_request:
+    branches:
+      - "**"
+    paths:
+      - "tools/healthcheck/**"
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tools/healthcheck
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+
+      - name: Run tests & generate HTML coverage report
+        # TODO: try to mock the env variables in the tests directly
+        env:
+          RABBITMQ_URL: "foo"
+          RABBITMQ_MONITORING_USERNAME: "foo"
+          RABBITMQ_MONITORING_PASSWORD: "bar"
+          DISPATCHER_INSTANCES: "bar"
+        run: |
+          coverage run --source=healthcheck -m unittest test_healthcheck.py
+          coverage report -m
+          coverage html
+
+      - name: Upload HTML coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          # Working directory is not used in the action
+          # https://github.com/actions/upload-artifact/issues/232
+          path: tools/healthcheck/htmlcov
+          retention-days: 7


### PR DESCRIPTION
Ajout d'un workflow de CI pour le healthcheck
Le workflow run les tests, génère un rapport de coverage et upload le rapport html.
Example de workflow : https://github.com/ansforge/SAMU-Hub-Sante/actions/runs/14615036120
(possibilité de télécharger le rapport de coverage dans les fichiers uploadés)