### PR TITLE
Hotfix/modeles branches per page

### DIFF
--- a/web/lrm/server/src/service/modeles.ts
+++ b/web/lrm/server/src/service/modeles.ts
@@ -73,10 +73,13 @@ const commitModelesChangesToExistingBranch = async ({
   return response.data;
 };
 
+const BRANCHES_PER_PAGE = 100;
+
 const getModelesBranchNames = async () => {
   const response = await client.rest.repos.listBranches({
     owner: GITHUB_OWNER,
     repo: GITHUB_REPO,
+    per_page: BRANCHES_PER_PAGE,
   });
   return response.data.map(({ name }) => name);
 };


### PR DESCRIPTION
Some branches were missing in the dropdown for source selection in the LRM Client.
The issue comes from the `listBranches` per_page param set by default to 20. It is now set to 100.
We should also cleanup the merged branches in the Modeles repository.