### PR TITLE
feat(dispatcher): error handling during conversion

### DIFF
--- a/hub/dispatcher/src/main/java/com/hubsante/hub/service/MessageHandler.java
+++ b/hub/dispatcher/src/main/java/com/hubsante/hub/service/MessageHandler.java
@@ -50,6 +50,10 @@ import static com.hubsante.hub.config.AmqpConfiguration.ORIGINAL_ROUTING_KEY;
 import static com.hubsante.hub.config.Constants.*;
 
 import static com.hubsante.hub.utils.ConfigUtils.sanitizeVhostForProm;
+import com.hubsante.hub.utils.ConversionRulesCommand;
+import com.hubsante.hub.utils.ConversionUtils;
+
+import static com.hubsante.hub.utils.EdxlUtils.HUB_ID;
 import static com.hubsante.hub.utils.EdxlUtils.edxlMessageFromHub;
 import static com.hubsante.hub.utils.EdxlUtils.getUseCaseFromMessage;
 import static com.hubsante.hub.utils.MessageUtils.*;
@@ -69,10 +73,11 @@ public class MessageHandler {
     @Autowired
     @Qualifier("jsonMapper")
     private ObjectMapper jsonMapper;
+    private final ConversionHandler conversionHandler;
 
-    private final static boolean DEFAULT_USE_XML_PREFERENCE = false;
+    private static final boolean DEFAULT_USE_XML_PREFERENCE = false;
 
-    public MessageHandler(RabbitTemplate rabbitTemplate, EdxlHandler edxlHandler, HubConfiguration hubConfig, Validator validator, MeterRegistry registry, XmlMapper xmlMapper, ObjectMapper jsonMapper) {
+    public MessageHandler(RabbitTemplate rabbitTemplate, EdxlHandler edxlHandler, HubConfiguration hubConfig, Validator validator, MeterRegistry registry, XmlMapper xmlMapper, ObjectMapper jsonMapper, ConversionHandler conversionHandler) {
         this.rabbitTemplate = rabbitTemplate;
         this.edxlHandler = edxlHandler;
         this.hubConfig = hubConfig;
@@ -80,6 +85,7 @@ public class MessageHandler {
         this.registry = registry;
         this.xmlMapper = xmlMapper;
         this.jsonMapper = jsonMapper;
+        this.conversionHandler = conversionHandler;
     }
 
     public HubConfiguration getHubConfig() {
@@ -134,6 +140,9 @@ public class MessageHandler {
 
         try {
             EdxlMessage errorEdxlMessage = edxlMessageFromHub(sender, wrapper);
+            String destinationExchange = DISTRIBUTION_EXCHANGE;
+            String routingKey = infoQueueName;
+
             Message errorAmqpMessage;
             if (convertToXML(sender, hubConfig.getUseXmlPreferences().getOrDefault(sender, DEFAULT_USE_XML_PREFERENCE))) {
                 errorAmqpMessage = new Message(edxlHandler.serializeXmlEDXL(errorEdxlMessage).getBytes(),
@@ -141,9 +150,20 @@ public class MessageHandler {
             } else {
                 errorAmqpMessage = new Message(edxlHandler.serializeJsonEDXL(errorEdxlMessage).getBytes(),
                         MessagePropertiesBuilder.newInstance().setContentType(MessageProperties.CONTENT_TYPE_JSON).build());
+
+                boolean isVersionConversion = ConversionUtils.requiresVersionConversion(hubConfig, errorEdxlMessage);
+
+                if (isVersionConversion) {
+                    ConversionRulesCommand conversionRulesCommand = new ConversionRulesCommand(errorEdxlMessage, this);
+                    String convertedMessage = conversionHandler.applyConversionRules(conversionRulesCommand);
+                    errorAmqpMessage = forwardedStringMessage(convertedMessage, errorAmqpMessage);
+                    destinationExchange = ConversionUtils.buildExchangeDestination(conversionRulesCommand.getSourceVHost(), conversionRulesCommand.getTargetVHost());
+                    routingKey = HUB_ID;
+                    log.info("Message transferred to exchange: {} with routing key: {}", destinationExchange, routingKey);
+                }
             }
 
-            rabbitTemplate.send(DISTRIBUTION_EXCHANGE, infoQueueName, errorAmqpMessage);
+            rabbitTemplate.send(destinationExchange, routingKey, errorAmqpMessage);
         } catch (JsonProcessingException e) {
             // This should never happen : we are serializing a POJO with 2 String attributes and a single enum
             log.error("Could not serialize Error for message " + error.getReferencedDistributionID(), e);

--- a/hub/dispatcher/src/test/java/com/hubsante/hub/service/DispatcherTest.java
+++ b/hub/dispatcher/src/test/java/com/hubsante/hub/service/DispatcherTest.java
@@ -30,6 +30,7 @@ import com.hubsante.hub.utils.MessageUtils;
 import com.hubsante.model.EdxlHandler;
 import com.hubsante.model.Validator;
 import com.hubsante.model.edxl.EdxlMessage;
+import com.hubsante.model.exception.ValidationException;
 import com.hubsante.model.report.ErrorCode;
 import com.hubsante.model.report.Error;
 import com.hubsante.model.technical.noreq.TechnicalNoreqWrapper;
@@ -73,6 +74,8 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
+
+import com.hubsante.hub.exception.SchemaValidationException;
 
 @SpringBootTest
 @ContextConfiguration(classes = HubApplication.class)
@@ -685,5 +688,38 @@ public class DispatcherTest {
             });
             assertEquals("The received message classname is not supported on this vhost", thrown.getMessage());
         }
+    }
+
+    @Test
+    @DisplayName("should transfer to another vhost when an error is raised after message transfer")
+    public void transferErrorToOtherVhost() throws IOException, ValidationException {
+        HubConfiguration hubConfigSpy = Mockito.spy(hubConfig);
+        doReturn("15-15_v2.0").when(hubConfigSpy).getVhost();
+        doReturn(new HashMap<>(Map.of(SAMU_A_ROUTING_KEY, false))).when(hubConfigSpy).getUseXmlPreferences();
+        doReturn(new String[] {"1.5"}).when(hubConfigSpy).getClientVersionsForPerimeter(SAMU_A_ROUTING_KEY, "15-15");
+
+        Validator validatorMock = Mockito.mock(Validator.class);
+        Mockito.doThrow(new SchemaValidationException("Mock schema validation error", "mock_distribution_id"))
+                .when(validatorMock).validateJSON(anyString(), any());
+
+        MessageHandler messageHandlerSpy = new MessageHandler(rabbitTemplate, edxlHandler, hubConfigSpy, validatorMock, registry, xmlMapper, jsonMapper, conversionHandler);
+        Dispatcher dispatcherSpy = new Dispatcher(messageHandlerSpy, rabbitTemplate, edxlHandler, xmlMapper, jsonMapper, conversionHandler);
+
+        Message message = createMessage("EDXL-DE", JSON, SAMU_A_ROUTING_KEY);
+
+        String exchangeName = "transfer_15-15_v2.0_to_15-15_v1.5";
+
+        // Mock call to converter (return same payload for error message)
+        doAnswer(invocation -> invocation.getArgument(0)).when(conversionHandler).callConversionService(anyString(), anyString(), anyString(), anyBoolean(), anyString());
+
+        AmqpRejectAndDontRequeueException errorThrown = assertThrows(AmqpRejectAndDontRequeueException.class, () -> {
+            dispatcherSpy.dispatch(message);
+        });
+
+        assertEquals("Mock schema validation error", errorThrown.getCause().getMessage());
+
+        ArgumentCaptor<Message> argument = ArgumentCaptor.forClass(Message.class);
+        Mockito.verify(rabbitTemplate, times(1)).send(
+                eq(exchangeName), eq("fr.health.hub"), argument.capture());
     }
 }

--- a/hub/dispatcher/src/test/java/com/hubsante/hub/service/DispatcherTest.java
+++ b/hub/dispatcher/src/test/java/com/hubsante/hub/service/DispatcherTest.java
@@ -722,4 +722,24 @@ public class DispatcherTest {
         Mockito.verify(rabbitTemplate, times(1)).send(
                 eq(exchangeName), eq("fr.health.hub"), argument.capture());
     }
+
+    @Test
+    @DisplayName("should forward error message directly when error is received after conversion")
+    public void sendErrorMessageToSameVhost() throws IOException, ValidationException {
+        HubConfiguration hubConfigSpy = Mockito.spy(hubConfig);
+        doReturn("15-15_v1.5").when(hubConfigSpy).getVhost();
+        doReturn(new HashMap<>(Map.of(SAMU_A_ROUTING_KEY, false))).when(hubConfigSpy).getUseXmlPreferences();
+        doReturn(new String[] {"1.5"}).when(hubConfigSpy).getClientVersionsForPerimeter(SAMU_A_ROUTING_KEY, "15-15");
+
+        MessageHandler messageHandlerSpy = new MessageHandler(rabbitTemplate, edxlHandler, hubConfigSpy, validator, registry, xmlMapper, jsonMapper, conversionHandler);
+        Dispatcher dispatcherSpy = new Dispatcher(messageHandlerSpy, rabbitTemplate, edxlHandler, xmlMapper, jsonMapper, conversionHandler);
+
+        Message errorMessage = createMessage("hub-error-to-samuA", JSON, "fr.health.hub");
+
+        dispatcherSpy.dispatch(errorMessage);
+
+        ArgumentCaptor<Message> argument = ArgumentCaptor.forClass(Message.class);
+        Mockito.verify(rabbitTemplate, times(1)).send(
+                eq(DISTRIBUTION_EXCHANGE), eq(SAMU_A_INFO_QUEUE), argument.capture());
+    }
 }

--- a/hub/dispatcher/src/test/java/com/hubsante/hub/service/DispatcherTest.java
+++ b/hub/dispatcher/src/test/java/com/hubsante/hub/service/DispatcherTest.java
@@ -725,7 +725,7 @@ public class DispatcherTest {
 
     @Test
     @DisplayName("should forward error message directly when error is received after conversion")
-    public void sendErrorMessageToSameVhost() throws IOException, ValidationException {
+    public void sendErrorMessageToSameVhost() throws IOException {
         HubConfiguration hubConfigSpy = Mockito.spy(hubConfig);
         doReturn("15-15_v1.5").when(hubConfigSpy).getVhost();
         doReturn(new HashMap<>(Map.of(SAMU_A_ROUTING_KEY, false))).when(hubConfigSpy).getUseXmlPreferences();
@@ -737,6 +737,34 @@ public class DispatcherTest {
         Message errorMessage = createMessage("hub-error-to-samuA", JSON, "fr.health.hub");
 
         dispatcherSpy.dispatch(errorMessage);
+
+        ArgumentCaptor<Message> argument = ArgumentCaptor.forClass(Message.class);
+        Mockito.verify(rabbitTemplate, times(1)).send(
+                eq(DISTRIBUTION_EXCHANGE), eq(SAMU_A_INFO_QUEUE), argument.capture());
+    }
+
+    @Test
+    @DisplayName("should send error message to sender info queue when error is raised")
+    public void sendErrorMessageWhenErrorIsRaised() throws IOException, ValidationException {
+        HubConfiguration hubConfigSpy = Mockito.spy(hubConfig);
+        doReturn("15-15_v1.5").when(hubConfigSpy).getVhost();
+        doReturn(new HashMap<>(Map.of(SAMU_A_ROUTING_KEY, false))).when(hubConfigSpy).getUseXmlPreferences();
+        doReturn(new String[] {"1.5"}).when(hubConfigSpy).getClientVersionsForPerimeter(SAMU_A_ROUTING_KEY, "15-15");
+
+        Validator validatorMock = Mockito.mock(Validator.class);
+        Mockito.doThrow(new SchemaValidationException("Mock schema validation error", "mock_distribution_id"))
+                .when(validatorMock).validateJSON(anyString(), any());
+
+        MessageHandler messageHandlerSpy = new MessageHandler(rabbitTemplate, edxlHandler, hubConfigSpy, validatorMock, registry, xmlMapper, jsonMapper, conversionHandler);
+        Dispatcher dispatcherSpy = new Dispatcher(messageHandlerSpy, rabbitTemplate, edxlHandler, xmlMapper, jsonMapper, conversionHandler);
+
+        Message message = createMessage("EDXL-DE", JSON, SAMU_A_ROUTING_KEY);
+
+        AmqpRejectAndDontRequeueException errorThrown = assertThrows(AmqpRejectAndDontRequeueException.class, () -> {
+            dispatcherSpy.dispatch(message);
+        });
+
+        assertEquals("Mock schema validation error", errorThrown.getCause().getMessage());
 
         ArgumentCaptor<Message> argument = ArgumentCaptor.forClass(Message.class);
         Mockito.verify(rabbitTemplate, times(1)).send(

--- a/hub/dispatcher/src/test/java/com/hubsante/hub/service/DispatcherTest.java
+++ b/hub/dispatcher/src/test/java/com/hubsante/hub/service/DispatcherTest.java
@@ -33,9 +33,11 @@ import com.hubsante.model.edxl.EdxlMessage;
 import com.hubsante.model.report.ErrorCode;
 import com.hubsante.model.report.Error;
 import com.hubsante.model.technical.noreq.TechnicalNoreqWrapper;
+
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.search.Search;
 import lombok.extern.slf4j.Slf4j;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
@@ -55,6 +57,7 @@ import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import jakarta.annotation.PostConstruct;
+
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
@@ -63,6 +66,7 @@ import static com.hubsante.hub.config.AmqpConfiguration.*;
 import static com.hubsante.hub.config.Constants.*;
 import static com.hubsante.hub.service.utils.MessageTestUtils.*;
 import static com.hubsante.hub.service.utils.MetricsUtils.*;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -125,7 +129,7 @@ public class DispatcherTest {
 
     @PostConstruct
     public void init() {
-        messageHandler = new MessageHandler(rabbitTemplate, edxlHandler, hubConfig, validator, registry, xmlMapper, jsonMapper);
+        messageHandler = new MessageHandler(rabbitTemplate, edxlHandler, hubConfig, validator, registry, xmlMapper, jsonMapper, conversionHandler);
         conversionHandler = Mockito.spy(new ConversionHandler(conversionWebClient));
         dispatcher = new Dispatcher(messageHandler, rabbitTemplate, edxlHandler, xmlMapper, jsonMapper, conversionHandler);
     }
@@ -138,6 +142,7 @@ public class DispatcherTest {
             }
         });
     }
+
     @Test
     @DisplayName("should send json message to the right exchange and routing key")
     public void shouldDispatchJsonToRightExchange() throws IOException {
@@ -155,7 +160,7 @@ public class DispatcherTest {
             ArgumentCaptor<Message> argCaptor = ArgumentCaptor.forClass(Message.class);
             // assert that the message was sent to the right exchange with the right routing key exactly 1 time
             Mockito.verify(rabbitTemplate, times(1)).send(
-                     eq(DISTRIBUTION_EXCHANGE), eq(SAMU_B_MESSAGE_QUEUE), argCaptor.capture());
+                    eq(DISTRIBUTION_EXCHANGE), eq(SAMU_B_MESSAGE_QUEUE), argCaptor.capture());
             // assert that the message has been converted according to the recipient preferences
             Message sentMessage = argCaptor.getValue();
             assertEquals(XML, sentMessage.getMessageProperties().getContentType());
@@ -352,7 +357,7 @@ public class DispatcherTest {
     public void malformedMessagefailed() throws IOException {
 
         // we test that the message has been rejected if we can't parse it
-        Message receivedMessage = createInvalidMessage("EDXL-DE/unparsable-content.json",  SAMU_A_ROUTING_KEY);
+        Message receivedMessage = createInvalidMessage("EDXL-DE/unparsable-content.json", SAMU_A_ROUTING_KEY);
         assertThrows(AmqpRejectAndDontRequeueException.class, () -> dispatcher.dispatch(receivedMessage));
 
         assertErrorHasBeenSent(SAMU_A_INFO_QUEUE, ErrorCode.UNRECOGNIZED_MESSAGE_FORMAT, SAMU_A_DISTRIBUTION_ID,
@@ -432,7 +437,7 @@ public class DispatcherTest {
     @DisplayName("should reject message with invalid json EDXL envelope")
     public void invalidJsonEDXLFails() throws IOException {
         try (MockedStatic<ConversionUtils> mockedConversionUtils = mockStatic(ConversionUtils.class)) {
-            mockedConversionUtils.when(() -> ConversionUtils.requiresVersionConversion(any(),any())).thenReturn(false);
+            mockedConversionUtils.when(() -> ConversionUtils.requiresVersionConversion(any(), any())).thenReturn(false);
             Message receivedMessage = createInvalidMessage("EDXL-DE/missing-EDXL-required-field.json", SAMU_A_ROUTING_KEY);
             assertThrows(AmqpRejectAndDontRequeueException.class, () -> dispatcher.dispatch(receivedMessage));
 
@@ -444,21 +449,21 @@ public class DispatcherTest {
 
     @Test
     @DisplayName("should send version converted message to transfer exchange")
-    public void sendToTransferExchange() throws IOException{
+    public void sendToTransferExchange() throws IOException {
         try (MockedStatic<ConversionUtils> mockedConversionUtils = mockStatic(ConversionUtils.class)) {
             Message message = createMessage("EDXL-DE", XML, SAMU_A_ROUTING_KEY);
             EdxlMessage edxlMessage = edxlHandler.deserializeXmlEDXL(new String(message.getBody(), StandardCharsets.UTF_8));
             String queueName = "fr.health.samuA";
             String exchangeName = "transfer_15-15_v1.5_to_15-15_v2.0";
 
-            mockedConversionUtils.when(() -> ConversionUtils.buildExchangeDestination( any(), any()))
+            mockedConversionUtils.when(() -> ConversionUtils.buildExchangeDestination(any(), any()))
                     .thenReturn(exchangeName);
-            mockedConversionUtils.when(() -> ConversionUtils.getTargetVHosts(hubConfig,edxlMessage))
+            mockedConversionUtils.when(() -> ConversionUtils.getTargetVHosts(hubConfig, edxlMessage))
                     .thenReturn(new String[]{"15-15_v2.0"});
             mockedConversionUtils.when(() -> ConversionUtils.getSourceVHost(hubConfig))
                     .thenReturn("15-15_v1.5");
 
-            ConversionRulesCommand conversionRulesCommand = new ConversionRulesCommand(edxlMessage,messageHandler);
+            ConversionRulesCommand conversionRulesCommand = new ConversionRulesCommand(edxlMessage, messageHandler);
 
             dispatcher.sendToTransferExchange(message.toString(), message, conversionRulesCommand);
 
@@ -468,7 +473,7 @@ public class DispatcherTest {
 
     @Test
     @DisplayName("should call sendToTransferExchange when there is a version conversion")
-    public void transferToOtherVhost() throws IOException{
+    public void transferToOtherVhost() throws IOException {
         try (MockedStatic<ConversionUtils> mockedConversionUtils = mockStatic(ConversionUtils.class)) {
             Dispatcher dispatcher = spy(new Dispatcher(messageHandler, rabbitTemplate, edxlHandler, xmlMapper, jsonMapper, conversionHandler));
 
@@ -476,7 +481,7 @@ public class DispatcherTest {
 
             String exchangeName = "transfer_15-15_v1.5_to_15-15_v2.0";
 
-            mockedConversionUtils.when(() -> ConversionUtils.buildExchangeDestination( any(), any()))
+            mockedConversionUtils.when(() -> ConversionUtils.buildExchangeDestination(any(), any()))
                     .thenReturn(exchangeName);
             mockedConversionUtils.when(() -> ConversionUtils.getSourceVHost(any())).thenReturn("15-15_v1.5");
             mockedConversionUtils.when(() -> ConversionUtils.getTargetVHosts(any(), any())).thenReturn(new String[]{"15-15_v2.0"});
@@ -505,6 +510,7 @@ public class DispatcherTest {
         assertErrorHasBeenSent(SAMU_A_INFO_QUEUE, ErrorCode.INVALID_MESSAGE, SAMU_A_DISTRIBUTION_ID,
                 "reference.invalid_key: is not defined in the schema and the schema does not allow additional properties");
     }
+
     @Test
     @DisplayName("should reject message with invalid xml content")
     public void invalidXmlContentFails() throws IOException {
@@ -593,11 +599,11 @@ public class DispatcherTest {
             // Mock conversion service to throw exception with error message from conversion service
             String conversionErrorMessage = "Conversion service error message";
             doThrow(new ConversionException(conversionErrorMessage, edxlMessage.getDistributionID()))
-                .when(conversionHandler).callConversionService(anyString(), anyString(), anyString(), anyBoolean(), anyString());
+                    .when(conversionHandler).callConversionService(anyString(), anyString(), anyString(), anyBoolean(), anyString());
 
             // Test that dispatching throws AmqpRejectAndDontRequeueException
             assertThrows(AmqpRejectAndDontRequeueException.class,
-                () -> testDispatcher.dispatch(receivedMessage));
+                    () -> testDispatcher.dispatch(receivedMessage));
 
             // Verify handleError was called with correct ConversionException
             ArgumentCaptor<ConversionException> exceptionCaptor = ArgumentCaptor.forClass(ConversionException.class);
@@ -650,7 +656,7 @@ public class DispatcherTest {
         when(hubConfig.getSupportedMessages()).thenReturn(List.of(supportedClassName));
         try (MockedStatic<EdxlUtils> mockedEdxlUtils = mockStatic(EdxlUtils.class)) {
             mockedEdxlUtils.when(() -> EdxlUtils.getUseCaseFromMessage(edxlMessage.getFirstContentMessage()))
-                .thenReturn(supportedClassName);
+                    .thenReturn(supportedClassName);
 
             new Dispatcher(messageHandler, rabbitTemplate, edxlHandler, xmlMapper, jsonMapper, conversionHandler);
 

--- a/hub/dispatcher/src/test/resources/sample/valid/hub-error-to-samuA/hub-error-to-samuA.json
+++ b/hub/dispatcher/src/test/resources/sample/valid/hub-error-to-samuA/hub-error-to-samuA.json
@@ -1,0 +1,75 @@
+{
+  "distributionID": "fr.health.hub_46e9ffaf-6afe-4aab-bbe8-2697a925f96f",
+  "senderID": "fr.health.hub",
+  "dateTimeSent": "2022-07-25T10:04:34+01:00",
+  "dateTimeExpires": "2072-07-25T10:04:34+01:00",
+  "distributionStatus": "Actual",
+  "distributionKind": "Error",
+  "descriptor": {
+    "language": "fr-FR",
+    "explicitAddress": {
+      "explicitAddressScheme": "hubex",
+      "explicitAddressValue": "fr.health.samuA"
+    }
+  },
+  "content": [
+    {
+      "jsonContent": {
+        "embeddedJsonContent": {
+          "message": {
+            "error": {
+              "errorCode": {
+                "statusCode": 300,
+                "statusString": "INVALID_MESSAGE"
+              },
+              "errorCause": "Mock invalid message error",
+              "sourceMessage": {
+                "distributionID": "fr.health.samuA_bb3c39c5-e036-49a7-b7a8-41b12d64058b",
+                "distributionKind": "Report",
+                "senderID": "fr.health.samuA",
+                "dateTimeSent": "2022-07-25T10:03:34+01:00",
+                "distributionStatus": "Actual",
+                "descriptor": {
+                  "language": "fr-FR",
+                  "explicitAddress": {
+                    "explicitAddressScheme": "hubex",
+                    "explicitAddressValue": "fr.health.samuC"
+                  }
+                },
+                "dateTimeExpires": "2072-09-27T08:23:34+02:00",
+                "content": [
+                  {
+                    "jsonContent": {
+                      "embeddedJsonContent": {
+                        "message": {
+                          "messageId": "fr.health.samuA_bb3c39c5-e036-49a7-b7a8-41b12d64058b",
+                          "sender": {
+                            "name": "samuA",
+                            "URI": "hubex:fr.health.samuA"
+                          },
+                          "dateTimeSent": "2022-07-25T10:03:34+01:00",
+                          "status": "Actual",
+                          "kind": "Report",
+                          "recipient": [
+                            {
+                              "name": "samuC",
+                              "URI": "hubex:fr.health.samuC"
+                            }
+                          ],
+                          "customContent": {
+                            "foo": "bar"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              "referencedDistributionID": "fr.health.samuA_bb3c39c5-e036-49a7-b7a8-41b12d64058b"
+            }
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## 🔗 Tâche Asana

- 🎯 [Gestion des erreurs : converter & dispatcher](https://app.asana.com/1/1201445755223134/project/1210740223939515/task/1210364694378745?focus=true)

## ⚙️ Documentation & stratégie technique

- https://ans-esante.atlassian.net/wiki/spaces/HUB/pages/1145438270/Gestion+des+erreurs

## 🔎 Détails

- Ajout d'une condition dans le flux de gestion des erreurs pour vérifier si le message doit être converti et transféré à un autre vhost
- Création de deux cas de tests : l'erreur est levé dans le vhost d'arrivé => vérifier que le message d'erreur est transféré; un message d'erreur est reçu par en provenance d'un autre vhost => vérifier qu'il est bien envoyé sur la queue info du destinataire.
