### PR TITLE
fix: make endpoints testable and reachable

### DIFF
--- a/tools/annuaire/Dockerfile
+++ b/tools/annuaire/Dockerfile
@@ -5,6 +5,9 @@ FROM python:3.12-slim
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
+# Set environment variable to indicate production mode
+ENV FLASK_PROD=1
+
 # Set the working directory in the container
 WORKDIR /app
 

--- a/tools/annuaire/Dockerfile
+++ b/tools/annuaire/Dockerfile
@@ -6,7 +6,7 @@ ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
 # Set environment variable to indicate production mode
-ENV FLASK_PROD=1
+ENV ENVIRONMENT=production
 
 # Set the working directory in the container
 WORKDIR /app

--- a/tools/annuaire/annuaire.py
+++ b/tools/annuaire/annuaire.py
@@ -23,10 +23,10 @@ HEADERS_COLUMNS_TO_KEEP = [
 ]
 
 
-def create_app(csv_dir=CSV_DIR):
+def create_app():
     app = Flask(__name__)
     register_routes(app)
-    csv_data = parse_csv(CSV_FILENAME, csv_dir)
+    csv_data = parse_csv(CSV_FILENAME)
     if csv_data is None:
         raise RuntimeError(
             "Erreur : impossible de charger le fichier CSV au démarrage."
@@ -35,8 +35,8 @@ def create_app(csv_dir=CSV_DIR):
     return app
 
 
-def parse_csv(filename, csv_dir=CSV_DIR):
-    path = os.path.join(csv_dir, filename)
+def parse_csv(filename):
+    path = os.path.join(CSV_DIR, filename)
     if not os.path.exists(path):
         logging.error(f"Fichier CSV introuvable : {path}")
         raise FileNotFoundError(f"{CSV_NOT_FOUND_MSG} : {filename}")

--- a/tools/annuaire/annuaire.py
+++ b/tools/annuaire/annuaire.py
@@ -67,5 +67,5 @@ def register_routes(app):
         return jsonify({"status": "UP", "service": "SAMU Hub Annuaire"}), 200
 
 
-if __name__ == "__main__":
+if os.environ.get("FLASK_PROD") == "1":
     app = create_app()

--- a/tools/annuaire/annuaire.py
+++ b/tools/annuaire/annuaire.py
@@ -3,6 +3,8 @@ from flask import Flask, jsonify, abort
 import csv
 import os
 
+ENVIRONMENT = os.environ.get("ENVIRONMENT")
+
 CSV_DIR = "/config"
 CSV_DATA_KEY = "CSV_DATA"
 CSV_FILENAME = "rabbitmq.clients-configuration.csv"
@@ -67,5 +69,5 @@ def register_routes(app):
         return jsonify({"status": "UP", "service": "SAMU Hub Annuaire"}), 200
 
 
-if os.environ.get("FLASK_PROD") == "1":
+if ENVIRONMENT == "production":
     app = create_app()

--- a/tools/annuaire/annuaire.py
+++ b/tools/annuaire/annuaire.py
@@ -20,11 +20,11 @@ HEADERS_COLUMNS_TO_KEEP = [
     "directCISU",
 ]
 
-app = Flask(__name__)
 
-
-def create_app():
-    csv_data = parse_csv(CSV_FILENAME)
+def create_app(csv_dir=CSV_DIR):
+    app = Flask(__name__)
+    register_routes(app)
+    csv_data = parse_csv(CSV_FILENAME, csv_dir)
     if csv_data is None:
         raise RuntimeError(
             "Erreur : impossible de charger le fichier CSV au démarrage."
@@ -33,8 +33,8 @@ def create_app():
     return app
 
 
-def parse_csv(filename):
-    path = os.path.join(CSV_DIR, filename)
+def parse_csv(filename, csv_dir=CSV_DIR):
+    path = os.path.join(csv_dir, filename)
     if not os.path.exists(path):
         logging.error(f"Fichier CSV introuvable : {path}")
         raise FileNotFoundError(f"{CSV_NOT_FOUND_MSG} : {filename}")
@@ -57,15 +57,15 @@ def select_columns(data: list[dict]) -> list[dict]:
     return data_updated
 
 
+def register_routes(app):
+    @app.get(API_ENDPOINT)
+    def get_json():
+        return jsonify(app.config[CSV_DATA_KEY])
+
+    @app.get(HEALTH_ENDPOINT)
+    def health_check():
+        return jsonify({"status": "UP", "service": "SAMU Hub Annuaire"}), 200
+
+
 if __name__ == "__main__":
     app = create_app()
-
-
-@app.get(API_ENDPOINT)
-def get_json():
-    return jsonify(app.config[CSV_DATA_KEY])
-
-
-@app.get(HEALTH_ENDPOINT)
-def health_check():
-    return jsonify({"status": "UP", "service": "SAMU Hub Annuaire"}), 200

--- a/tools/annuaire/test_annuaire.py
+++ b/tools/annuaire/test_annuaire.py
@@ -91,12 +91,12 @@ class AnnuaireTestCase(unittest.TestCase):
     def test_parse_csv_file_not_found(self):
         with self.assertLogs(level="ERROR") as cm:
             with self.assertRaises(FileNotFoundError):
-                parse_csv("non_existent.csv")
+                parse_csv("non_existent.csv", csv_dir=self.tempdir.name)
         self.assertIn(CSV_NOT_FOUND_MSG, cm.output[0])
 
     def test_api(self):
         with mock.patch(FOLDER_NAME_PATCH_PATH, self.tempdir.name):
-            app = annuaire.create_app()
+            app = annuaire.create_app(csv_dir=self.tempdir.name)
             client = app.test_client()
             response = client.get(API_ENDPOINT)
             self.assertEqual(response.status_code, 200)
@@ -104,7 +104,7 @@ class AnnuaireTestCase(unittest.TestCase):
 
     def test_parse_csv_valid(self):
         with mock.patch(FOLDER_NAME_PATCH_PATH, self.tempdir.name):
-            data = parse_csv(CSV_FILENAME)
+            data = parse_csv(CSV_FILENAME, csv_dir=self.tempdir.name)
 
             expected_rows = [
                 {
@@ -144,14 +144,14 @@ class AnnuaireTestCase(unittest.TestCase):
 
     def test_select_columns(self):
         with mock.patch(FOLDER_NAME_PATCH_PATH, self.tempdir.name):
-            data = parse_csv(CSV_FILENAME)
+            data = parse_csv(CSV_FILENAME, csv_dir=self.tempdir.name)
             result = select_columns(data)
             for row in result:
                 self.assertEqual(set(row.keys()), set(HEADERS_COLUMNS_TO_KEEP))
 
     def test_healthcheck(self):
         with mock.patch(FOLDER_NAME_PATCH_PATH, self.tempdir.name):
-            app = annuaire.create_app()
+            app = annuaire.create_app(csv_dir=self.tempdir.name)
             client = app.test_client()
             response = client.get(HEALTH_ENDPOINT)
             self.assertEqual(response.status_code, 200)

--- a/tools/annuaire/test_annuaire.py
+++ b/tools/annuaire/test_annuaire.py
@@ -91,12 +91,12 @@ class AnnuaireTestCase(unittest.TestCase):
     def test_parse_csv_file_not_found(self):
         with self.assertLogs(level="ERROR") as cm:
             with self.assertRaises(FileNotFoundError):
-                parse_csv("non_existent.csv", csv_dir=self.tempdir.name)
+                parse_csv("non_existent.csv")
         self.assertIn(CSV_NOT_FOUND_MSG, cm.output[0])
 
     def test_api(self):
         with mock.patch(FOLDER_NAME_PATCH_PATH, self.tempdir.name):
-            app = annuaire.create_app(csv_dir=self.tempdir.name)
+            app = annuaire.create_app()
             client = app.test_client()
             response = client.get(API_ENDPOINT)
             self.assertEqual(response.status_code, 200)
@@ -104,7 +104,7 @@ class AnnuaireTestCase(unittest.TestCase):
 
     def test_parse_csv_valid(self):
         with mock.patch(FOLDER_NAME_PATCH_PATH, self.tempdir.name):
-            data = parse_csv(CSV_FILENAME, csv_dir=self.tempdir.name)
+            data = parse_csv(CSV_FILENAME)
 
             expected_rows = [
                 {
@@ -144,14 +144,14 @@ class AnnuaireTestCase(unittest.TestCase):
 
     def test_select_columns(self):
         with mock.patch(FOLDER_NAME_PATCH_PATH, self.tempdir.name):
-            data = parse_csv(CSV_FILENAME, csv_dir=self.tempdir.name)
+            data = parse_csv(CSV_FILENAME)
             result = select_columns(data)
             for row in result:
                 self.assertEqual(set(row.keys()), set(HEADERS_COLUMNS_TO_KEEP))
 
     def test_healthcheck(self):
         with mock.patch(FOLDER_NAME_PATCH_PATH, self.tempdir.name):
-            app = annuaire.create_app(csv_dir=self.tempdir.name)
+            app = annuaire.create_app()
             client = app.test_client()
             response = client.get(HEALTH_ENDPOINT)
             self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
- Déplacement des routes (/annuaire/api et /annuaire/health) dans une fonction register_routes(app) pour pouvoir les enregistrer dans la fonction create_app(), tout en gardant la définition des endpoints à la fin.

- Suppression de la création globale par défaut pour éviter les erreurs lors de l’import (import annuaire). L’instance globale de l’application n’est créée que lorsque la variable d’environnement FLASK_PROD est définie à 1.