### PR TITLE
chore: add CORS policies for annuaire Flask API

### DIFF
--- a/tools/annuaire/annuaire.py
+++ b/tools/annuaire/annuaire.py
@@ -1,5 +1,6 @@
 import logging
 from flask import Flask, jsonify, abort
+from flask_cors import CORS
 import csv
 import os
 
@@ -25,6 +26,7 @@ HEADERS_COLUMNS_TO_KEEP = [
 
 def create_app():
     app = Flask(__name__)
+    CORS(app, resources={r"/annuaire/api/": {"origins": ["https://qualification.hub.esante.gouv.fr", "https://hub.esante.gouv.fr"]}})
     register_routes(app)
     csv_data = parse_csv(CSV_FILENAME)
     if csv_data is None:


### PR DESCRIPTION
## 🔎 Détails

Ajoute des CORS policies à l'API Flask Annuaire pour permettre au landing de faire un fetch (que ce soit sur qualif, ou bac à sable)

## 📄 Documentation

> Ajoutez un (des) lien(s) vers la documentation si nécessaire

## 📸 Captures d'écran

| Avant | Après |
| ----- | ----- |
|   <img width="1911" height="976" alt="image" src="https://github.com/user-attachments/assets/39da17f0-33a1-408d-8e68-7bd18e5e9951" />    |       |

## 🔗Ticket associé

[Asana]()
