### PR TITLE
chore/lrm/server : update amqplib

### DIFF
--- a/web/lrm/server/package-lock.json
+++ b/web/lrm/server/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "amqplib": "^0.10.3",
+        "amqplib": "^0.10.8",
         "body-parser": "^2.2.1",
         "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
@@ -25,7 +25,7 @@
         "@babel/preset-env": "^7.26.9",
         "@babel/preset-typescript": "^7.27.0",
         "@tsconfig/recommended": "^1.0.8",
-        "@types/amqplib": "^0.10.7",
+        "@types/amqplib": "^0.10.8",
         "@types/cookie-parser": "^1.4.8",
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.0",

--- a/web/lrm/server/package.json
+++ b/web/lrm/server/package.json
@@ -17,7 +17,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "amqplib": "^0.10.3",
+    "amqplib": "^0.10.8",
     "body-parser": "^2.2.1",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
@@ -33,7 +33,7 @@
     "@babel/preset-env": "^7.26.9",
     "@babel/preset-typescript": "^7.27.0",
     "@tsconfig/recommended": "^1.0.8",
-    "@types/amqplib": "^0.10.7",
+    "@types/amqplib": "^0.10.8",
     "@types/cookie-parser": "^1.4.8",
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.0",


### PR DESCRIPTION
## 🔎 Détails

Mise à jour de la dépendance amqplib pour garantir la compatibilité avec RabbitMQ suite à la montée de version de 4.0.2 vers 4.2.
Aucun impact fonctionnel attendu : le package-lock.json était déjà aligné sur une version supérieure.

## 📄 Documentation

- https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.1.0

## 📸 Captures d'écran

| Avant | Après |
| ----- | ----- |
|       |       |

## 🔗Ticket associé

[Asana]()

## ✅ A vérifier

- [ ] J'ai exécuté les tests e2e du LRM client localement, s'il a été modifié
