### PR TITLE
fix(dispatcher): set client preferences as top choice for xml conversion

### DIFF
--- a/hub/README.md
+++ b/hub/README.md
@@ -86,11 +86,8 @@ To format it, run the following command in the `hub/dispatcher` folder:
 
 ### Format license headers
 
-The license headers are managed using the [Gradle License Plugin](https://github.com/hierynomus/license-gradle-plugin).
-To format it, run the following command in the `hub/dispatcher` folder:
-```bash
-./gradlew licenseFormat
-```
+The license headers are managed by Spotless (configured in [./dispatcher/gradle/spotless.gradle](./dispatcher/gradle/spotless.gradle))
+They are applied when running `./gradlew spotlessApply`.
 
 ### Message Integrity Testing
 

--- a/hub/dispatcher/src/main/java/com/hubsante/hub/service/MessageHandler.java
+++ b/hub/dispatcher/src/main/java/com/hubsante/hub/service/MessageHandler.java
@@ -81,8 +81,6 @@ public class MessageHandler {
     private final ConversionHandler conversionHandler;
     private static final StructuredLogger structuredLog = new StructuredLogger(log);
 
-    private static final boolean DEFAULT_USE_XML_PREFERENCE = false;
-
     public MessageHandler(
             RabbitTemplate rabbitTemplate,
             EdxlHandler edxlHandler,
@@ -202,11 +200,7 @@ public class MessageHandler {
             String routingKey = infoQueueName;
 
             Message errorAmqpMessage;
-            if (convertToXML(
-                    sender,
-                    hubConfig
-                            .getUseXmlPreferences()
-                            .getOrDefault(sender, DEFAULT_USE_XML_PREFERENCE))) {
+            if (convertToXML(sender, hubConfig.getUseXmlPreferences().getOrDefault(sender, null))) {
                 errorAmqpMessage =
                         new Message(
                                 edxlHandler.serializeXmlEDXL(errorEdxlMessage).getBytes(),
@@ -506,9 +500,7 @@ public class MessageHandler {
         try {
             if (convertToXML(
                     recipientId,
-                    hubConfig
-                            .getUseXmlPreferences()
-                            .getOrDefault(recipientId, DEFAULT_USE_XML_PREFERENCE))) {
+                    hubConfig.getUseXmlPreferences().getOrDefault(recipientId, null))) {
                 edxlString = edxlHandler.serializeXmlEDXL(edxlMessage);
                 fwdAmqpProperties.setContentType(MessageProperties.CONTENT_TYPE_XML);
             } else {

--- a/hub/dispatcher/src/main/java/com/hubsante/hub/service/MessageHandler.java
+++ b/hub/dispatcher/src/main/java/com/hubsante/hub/service/MessageHandler.java
@@ -200,7 +200,7 @@ public class MessageHandler {
             String routingKey = infoQueueName;
 
             Message errorAmqpMessage;
-            if (convertToXML(sender, hubConfig.getUseXmlPreferences().getOrDefault(sender, null))) {
+            if (convertToXML(sender, hubConfig.getUseXmlPreferences().get(sender))) {
                 errorAmqpMessage =
                         new Message(
                                 edxlHandler.serializeXmlEDXL(errorEdxlMessage).getBytes(),
@@ -498,9 +498,7 @@ public class MessageHandler {
         String messageType = getUseCaseFromMessage(edxlMessage.getFirstContentMessage());
 
         try {
-            if (convertToXML(
-                    recipientId,
-                    hubConfig.getUseXmlPreferences().getOrDefault(recipientId, null))) {
+            if (convertToXML(recipientId, hubConfig.getUseXmlPreferences().get(recipientId))) {
                 edxlString = edxlHandler.serializeXmlEDXL(edxlMessage);
                 fwdAmqpProperties.setContentType(MessageProperties.CONTENT_TYPE_XML);
             } else {

--- a/hub/dispatcher/src/main/java/com/hubsante/hub/utils/MessageUtils.java
+++ b/hub/dispatcher/src/main/java/com/hubsante/hub/utils/MessageUtils.java
@@ -47,9 +47,6 @@ public class MessageUtils {
     private static final StructuredLogger structuredLog = new StructuredLogger(log);
 
     static final String HEALTH_PREFIX = "fr.health";
-    private static final String CISU_LRM_USER = "fr.cisu.sdisY";
-
-    private static final String SDISZ_LRM_USER = "fr.fire.nexsis.sdisZ";
 
     public static String getSenderFromRoutingKey(Message message) {
         String receivedRoutingKey = message.getMessageProperties().getReceivedRoutingKey();
@@ -204,14 +201,15 @@ public class MessageUtils {
     }
 
     public static boolean convertToXML(String recipientId, Boolean useXML) {
-        // sending message to outer hubex is always XML
-        if (!(recipientId.startsWith(HEALTH_PREFIX)
-                || recipientId.equals(CISU_LRM_USER)
-                || recipientId.equals(SDISZ_LRM_USER))) {
+        if (useXML != null) {
+            return useXML;
+        }
+        // Handle cross hubex communication with NexSIS
+        if (recipientId.matches("^fr\\.fire.*")) {
             return true;
         }
-        // sending message to health clients is based on client preference (default to JSON)
-        return useXML != null && useXML;
+        // Default to JSON
+        return false;
     }
 
     public static boolean isJSON(Message message) {

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,7 +9,3 @@ pre-commit:
       root: "hub/dispatcher/"
       run: ./gradlew spotlessApply
       stage_fixed: true
-    dispatcher-license-format:
-      root: "hub/dispatcher/"
-      run: "./gradlew licenseFormat"
-      stage_fixed: true


### PR DESCRIPTION
## 🔎 Détails

Fix d'un bug relevé sur la conversion XML/JSON sur le LRM de test en utilisant le client `fr.cisu.sdisz`.

Les clients LRM utilisés pour mocker NexSIS avaient un comportement hardcodé dans le dispatcher qui annulait la conversion de JSON vers XML, qui est le comportement attendu pour les clients côtés pompiers.
Ce n'était pas le cas de `fr.cisu.sdisz` qui recevait ainsi les messages au format XML malgré le champ `useXML` valorisé à `false` dans le `client-preferences.csv`.

Changements :
- Suppression de la logique hardcodée par clientId pour certains utilisateurs LRM
- Le contenu du `client-preferences.csv` fait foi : si il est valorisé à `true` ou `false` pour un client, on ne veut pas bypass ce comportement dans el dispatcher (une seule source de vérité)
- Pour l'instant les communications inter-hubex se font uniquement avec NexSIS via XML, mais il est possible que d'autres forces (police, gendarmerie) souhaitent rester sur du JSON. Ainsi on peut forcer de la conversion JSON -> XML uniquement pour les destinataires en `fr.fire.*` pour l'instant (le csv faisait fois en cas de conflit).

- *REPO SETUP :* Suppression de l'étape de gestion des licenses par pre-commit (géré désormais par spotless, oubli dans la migration) & mise à jour du README à ce sujet.

## 📄 Documentation

### Fonctionnement actuel

<img width="1682" height="1192" alt="image" src="https://github.com/user-attachments/assets/ea70f154-1841-4512-a054-87688e1d160d" />

### Fonctionnement souhaité

<img width="964" height="939" alt="image" src="https://github.com/user-attachments/assets/30543c91-f424-4505-8b25-778d3d6cd989" />
