### PR TITLE
Healthcheck timeout handling

### DIFF
--- a/tools/healthcheck/checks/annuaire.py
+++ b/tools/healthcheck/checks/annuaire.py
@@ -1,9 +1,8 @@
-import requests
 from prometheus_client import Gauge
 
 from checks.checker import IChecker
 from checks.status import Status
-from config import HTTP_TIMEOUT
+from http_client import http_session
 
 ANNUAIRE_HEALTH_URL = (
     "http://annuaire-service.annuaire.svc.cluster.local/annuaire/health"
@@ -16,7 +15,7 @@ class AnnuaireHealthcheck(IChecker):
     )
 
     def perform_checks(self):
-        response = requests.get(ANNUAIRE_HEALTH_URL, timeout=HTTP_TIMEOUT)
+        response = http_session.get(ANNUAIRE_HEALTH_URL)
         response.raise_for_status()
         data = response.json()
         status = data.get("status", Status.UNKNOWN.value)

--- a/tools/healthcheck/checks/checker.py
+++ b/tools/healthcheck/checks/checker.py
@@ -13,9 +13,10 @@ class IChecker(ABC):
         pass
 
     def check_wrapper(self):
+        component_name = type(self).__name__
         try:
+            logging.info(f"Performing {component_name} check")
             return self.perform_checks()
         except Exception:
-            component_name = type(self).__name__
             logging.exception(f"Error occurred when performing {component_name} check")
             return self.check_failure_fallback()

--- a/tools/healthcheck/checks/converter.py
+++ b/tools/healthcheck/checks/converter.py
@@ -1,9 +1,8 @@
-import requests
 from prometheus_client import Gauge
 
 from checks.checker import IChecker
 from checks.status import Status
-from config import HTTP_TIMEOUT
+from http_client import http_session
 
 CONVERTER_HEALTH_URL = "http://converter.app.svc.cluster.local:8080/health"
 
@@ -14,7 +13,7 @@ class ConverterHealthcheck(IChecker):
     )
 
     def perform_checks(self):
-        response = requests.get(CONVERTER_HEALTH_URL, timeout=HTTP_TIMEOUT)
+        response = http_session.get(CONVERTER_HEALTH_URL)
         response.raise_for_status()
         data = response.json()
         status = data.get("status", Status.UNKNOWN.value)

--- a/tools/healthcheck/checks/dispatcher.py
+++ b/tools/healthcheck/checks/dispatcher.py
@@ -1,12 +1,13 @@
-import requests
 import logging
 import os
+
+import requests
 from prometheus_client import Gauge
 from collections import OrderedDict
 
 from checks.checker import IChecker
 from checks.status import Status
-from config import HTTP_TIMEOUT
+from http_client import http_session
 
 DISPATCHER_INSTANCES_ENV_VAR = os.getenv("DISPATCHER_INSTANCES")
 DISPATCHER_INSTANCES = (
@@ -45,7 +46,7 @@ class DispatchersHealthcheck(IChecker):
             dispatcher_health_url = (
                 f"http://{app_name}.app.svc.cluster.local:8080/actuator/health"
             )
-            response = requests.get(dispatcher_health_url, timeout=HTTP_TIMEOUT)
+            response = http_session.get(dispatcher_health_url)
             response.raise_for_status()
             data = response.json()
             status = data.get("status", Status.UNKNOWN.value)

--- a/tools/healthcheck/checks/dispatcher.py
+++ b/tools/healthcheck/checks/dispatcher.py
@@ -27,7 +27,6 @@ class DispatchersHealthcheck(IChecker):
             self.dispatcher_status_metric.labels(dispatcher=dispatcher).set(0)
 
     def perform_checks(self):
-        logging.info(f"Checking health of dispatcher instances: {DISPATCHER_INSTANCES}")
         result = {}
         with ThreadPoolExecutor() as executor:
             futures = [
@@ -46,6 +45,7 @@ class DispatchersHealthcheck(IChecker):
         return result
 
     def single_dispatcher_healthcheck(self, app_name):
+        logging.info(f"Checking health of dispatcher instance: {app_name}")
         try:
             dispatcher_health_url = (
                 f"http://{app_name}.app.svc.cluster.local:8080/actuator/health"

--- a/tools/healthcheck/checks/dispatcher.py
+++ b/tools/healthcheck/checks/dispatcher.py
@@ -30,7 +30,10 @@ class DispatchersHealthcheck(IChecker):
         result = {}
         with ThreadPoolExecutor() as executor:
             futures = [
-                (instance, executor.submit(self.single_dispatcher_healthcheck, instance))
+                (
+                    instance,
+                    executor.submit(self.single_dispatcher_healthcheck, instance),
+                )
                 for instance in DISPATCHER_INSTANCES
             ]
             for instance, future in futures:

--- a/tools/healthcheck/checks/dispatcher.py
+++ b/tools/healthcheck/checks/dispatcher.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from concurrent.futures import ThreadPoolExecutor
 
 import requests
 from prometheus_client import Gauge
@@ -28,10 +29,13 @@ class DispatchersHealthcheck(IChecker):
     def perform_checks(self):
         logging.info(f"Checking health of dispatcher instances: {DISPATCHER_INSTANCES}")
         result = {}
-        for dispatcher_instance in DISPATCHER_INSTANCES:
-            result[dispatcher_instance] = self.single_dispatcher_healthcheck(
-                dispatcher_instance
-            )
+        with ThreadPoolExecutor() as executor:
+            futures = [
+                (instance, executor.submit(self.single_dispatcher_healthcheck, instance))
+                for instance in DISPATCHER_INSTANCES
+            ]
+            for instance, future in futures:
+                result[instance] = future.result()
         return result
 
     def check_failure_fallback(self):

--- a/tools/healthcheck/checks/hubex_partners_shovels.py
+++ b/tools/healthcheck/checks/hubex_partners_shovels.py
@@ -90,10 +90,6 @@ class HubexPartnersHealthcheck(IChecker):
                 ).set(0)
 
     def perform_checks(self):
-        logging.info(
-            f"Checking health of hubex partners connexions: {self.SHOVELS_MAP}"
-        )
-
         response = http_session.get(
             SHOVEL_STATUS_URL,
             auth=(RABBITMQ_MONITORING_USERNAME, RABBITMQ_MONITORING_PASSWORD),
@@ -104,6 +100,9 @@ class HubexPartnersHealthcheck(IChecker):
         result = {}
         for vhost, shovels_list in self.SHOVELS_MAP.items():
             for shovel in shovels_list:
+                logging.info(
+                    f"Checking health of hubex partner connection for vhost {vhost} and shovel {shovel}"
+                )
                 shovel_status = check_shovel_response(data, vhost, shovel)
                 shovel_label = f"{vhost}-{shovel}"
                 result[shovel_label] = shovel_status

--- a/tools/healthcheck/checks/hubex_partners_shovels.py
+++ b/tools/healthcheck/checks/hubex_partners_shovels.py
@@ -1,13 +1,13 @@
-import requests
 import logging
 import os
 import sys
+
 from prometheus_client import Gauge
 
 from checks.checker import IChecker
 from checks.status import Status
+from http_client import http_session
 from config import (
-    HTTP_TIMEOUT,
     RABBITMQ_URL,
     RABBITMQ_MONITORING_USERNAME,
     RABBITMQ_MONITORING_PASSWORD,
@@ -94,11 +94,10 @@ class HubexPartnersHealthcheck(IChecker):
             f"Checking health of hubex partners connexions: {self.SHOVELS_MAP}"
         )
 
-        response = requests.get(
+        response = http_session.get(
             SHOVEL_STATUS_URL,
             auth=(RABBITMQ_MONITORING_USERNAME, RABBITMQ_MONITORING_PASSWORD),
             verify=RABBITMQ_CA_CERT_PATH,
-            timeout=HTTP_TIMEOUT,
         )
         response.raise_for_status()
         data = response.json()

--- a/tools/healthcheck/checks/rabbitmq.py
+++ b/tools/healthcheck/checks/rabbitmq.py
@@ -1,10 +1,9 @@
-import requests
 from prometheus_client import Gauge
 
 from checks.checker import IChecker
 from checks.status import Status
+from http_client import http_session
 from config import (
-    HTTP_TIMEOUT,
     RABBITMQ_URL,
     RABBITMQ_MONITORING_USERNAME,
     RABBITMQ_MONITORING_PASSWORD,
@@ -20,11 +19,10 @@ class RabbitMQHealthcheck(IChecker):
     )
 
     def perform_checks(self):
-        response = requests.get(
+        response = http_session.get(
             RABBITMQ_HEALTH_URL,
             auth=(RABBITMQ_MONITORING_USERNAME, RABBITMQ_MONITORING_PASSWORD),
             verify=RABBITMQ_CA_CERT_PATH,
-            timeout=HTTP_TIMEOUT,
         )
         response.raise_for_status()
         status = response.json().get("status", Status.UNKNOWN.value)

--- a/tools/healthcheck/healthcheck.py
+++ b/tools/healthcheck/healthcheck.py
@@ -60,8 +60,7 @@ def update_metrics_before_scrapping():
     if request.path == METRICS_ENDPOINT:
         with ThreadPoolExecutor() as executor:
             futures = [
-                executor.submit(checker.check_wrapper)
-                for checker in internal_checkers
+                executor.submit(checker.check_wrapper) for checker in internal_checkers
             ]
             for future in futures:
                 future.result()

--- a/tools/healthcheck/healthcheck.py
+++ b/tools/healthcheck/healthcheck.py
@@ -1,5 +1,7 @@
 import json
 import logging
+from concurrent.futures import ThreadPoolExecutor
+
 from flask import Flask, Response, request
 from collections import OrderedDict
 from prometheus_flask_exporter import PrometheusMetrics
@@ -37,12 +39,17 @@ def compute_globale_status(custom_checkers):
     global_status = Status.UP.value
     components = OrderedDict()
 
-    for checker in custom_checkers:
-        health_statuses = checker.check_wrapper()
-        for component, status in health_statuses.items():
-            components[component] = status
-            if status["status"] == Status.DOWN.value:
-                global_status = Status.DOWN.value
+    with ThreadPoolExecutor() as executor:
+        futures = [
+            (checker, executor.submit(checker.check_wrapper))
+            for checker in custom_checkers
+        ]
+        for _, future in futures:
+            health_statuses = future.result()
+            for component, status in health_statuses.items():
+                components[component] = status
+                if status["status"] == Status.DOWN.value:
+                    global_status = Status.DOWN.value
 
     result = OrderedDict([("status", global_status), ("components", components)])
     return remove_error_keys(result)

--- a/tools/healthcheck/healthcheck.py
+++ b/tools/healthcheck/healthcheck.py
@@ -58,8 +58,13 @@ def compute_globale_status(custom_checkers):
 @app.before_request
 def update_metrics_before_scrapping():
     if request.path == METRICS_ENDPOINT:
-        for checker in internal_checkers:
-            checker.check_wrapper()
+        with ThreadPoolExecutor() as executor:
+            futures = [
+                executor.submit(checker.check_wrapper)
+                for checker in internal_checkers
+            ]
+            for future in futures:
+                future.result()
 
 
 @app.route(HEALTH_EXTERNAL_ENDPOINT, methods=["GET"])

--- a/tools/healthcheck/http_client.py
+++ b/tools/healthcheck/http_client.py
@@ -1,0 +1,12 @@
+import requests
+
+from config import HTTP_TIMEOUT
+
+
+class TimeoutSession(requests.Session):
+    def request(self, method, url, **kwargs):
+        kwargs.setdefault("timeout", HTTP_TIMEOUT)
+        return super().request(method, url, **kwargs)
+
+
+http_session = TimeoutSession()

--- a/tools/healthcheck/tests/test_healthcheck.py
+++ b/tools/healthcheck/tests/test_healthcheck.py
@@ -394,7 +394,8 @@ class HealthCheckTestCase(unittest.TestCase):
         mock_get.side_effect = side_effect
 
         with patch(
-            "checks.dispatcher.DISPATCHER_INSTANCES", [dispatcher1_name, dispatcher2_name]
+            "checks.dispatcher.DISPATCHER_INSTANCES",
+            [dispatcher1_name, dispatcher2_name],
         ):
             with app.test_client() as client:
                 response = client.get(HEALTH_INTERNAL_ENDPOINT)

--- a/tools/healthcheck/tests/test_healthcheck.py
+++ b/tools/healthcheck/tests/test_healthcheck.py
@@ -13,6 +13,8 @@ import logging
 with patch("checks.hubex_partners_shovels.open", mock_open(read_data="vhost1;queue1")):
     from healthcheck import HEALTH_INTERNAL_ENDPOINT, HEALTH_EXTERNAL_ENDPOINT, app
 
+MOCK_TARGET = "http_client.http_session.get"
+
 
 class HealthCheckTestCase(unittest.TestCase):
     def setUp(self):
@@ -91,18 +93,16 @@ class HealthCheckTestCase(unittest.TestCase):
     @parameterized.expand(
         [
             (
+                {"status": "ok"},
+                {"status": "UP", "components": {}},
+                {"status": "UP"},
+                {"status": "UP"},
                 [
-                    {"status": "ok"},
-                    {"status": "UP", "components": {}},
-                    {"status": "UP"},
-                    {"status": "UP"},
-                    [
-                        {
-                            "vhost": "vhost1",
-                            "src_queue": "queue1",
-                            "blocked_status": "running",
-                        },
-                    ],
+                    {
+                        "vhost": "vhost1",
+                        "src_queue": "queue1",
+                        "blocked_status": "running",
+                    },
                 ],
                 "UP",
                 "UP",
@@ -112,18 +112,16 @@ class HealthCheckTestCase(unittest.TestCase):
                 "UP",
             ),
             (
+                {"status": "down"},
+                {"status": "UP", "components": {}},
+                {"status": "UP"},
+                {"status": "UP"},
                 [
-                    {"status": "down"},
-                    {"status": "UP", "components": {}},
-                    {"status": "UP"},
-                    {"status": "UP"},
-                    [
-                        {
-                            "vhost": "vhost1",
-                            "src_queue": "queue1",
-                            "blocked_status": "running",
-                        },
-                    ],
+                    {
+                        "vhost": "vhost1",
+                        "src_queue": "queue1",
+                        "blocked_status": "running",
+                    },
                 ],
                 "DOWN",
                 "DOWN",
@@ -133,18 +131,16 @@ class HealthCheckTestCase(unittest.TestCase):
                 "UP",
             ),
             (
+                {"status": "ok"},
+                {"status": "DOWN", "components": {}},
+                {"status": "DOWN"},
+                {"status": "DOWN"},
                 [
-                    {"status": "ok"},
-                    {"status": "DOWN", "components": {}},
-                    {"status": "DOWN"},
-                    {"status": "DOWN"},
-                    [
-                        {
-                            "vhost": "vhost1",
-                            "src_queue": "queue1",
-                            "blocked_status": "running",
-                        },
-                    ],
+                    {
+                        "vhost": "vhost1",
+                        "src_queue": "queue1",
+                        "blocked_status": "running",
+                    },
                 ],
                 "DOWN",
                 "UP",
@@ -154,18 +150,16 @@ class HealthCheckTestCase(unittest.TestCase):
                 "UP",
             ),
             (
+                {"status": "down"},
+                {"status": "DOWN", "components": {}},
+                {"status": "DOWN"},
+                {"status": "DOWN"},
                 [
-                    {"status": "down"},
-                    {"status": "DOWN", "components": {}},
-                    {"status": "DOWN"},
-                    {"status": "DOWN"},
-                    [
-                        {
-                            "vhost": "vhost1",
-                            "src_queue": "queue1",
-                            "blocked_status": "not_running",
-                        },
-                    ],
+                    {
+                        "vhost": "vhost1",
+                        "src_queue": "queue1",
+                        "blocked_status": "not_running",
+                    },
                 ],
                 "DOWN",
                 "DOWN",
@@ -176,10 +170,14 @@ class HealthCheckTestCase(unittest.TestCase):
             ),
         ]
     )
-    @patch("requests.get")
+    @patch(MOCK_TARGET)
     def test_health_check(
         self,
-        side_effect,
+        rabbitmq_response,
+        dispatcher_response,
+        converter_response,
+        annuaire_response,
+        shovel_status_response,
         global_status,
         rabbitmq_status,
         dispatcher_status,
@@ -188,8 +186,13 @@ class HealthCheckTestCase(unittest.TestCase):
         shovel_status,
         mock_get,
     ):
-        mock_get.return_value.status_code = 200
-        mock_get.return_value.json.side_effect = side_effect
+        mock_get.side_effect = self.create_mock_side_effect(
+            rabbitmq_response=rabbitmq_response,
+            dispatcher_response=dispatcher_response,
+            converter_response=converter_response,
+            annuaire_response=annuaire_response,
+            shovel_status_response=shovel_status_response,
+        )
 
         with patch("checks.dispatcher.DISPATCHER_INSTANCES", ["dispatcher1"]):
             with app.test_client() as client:
@@ -213,7 +216,7 @@ class HealthCheckTestCase(unittest.TestCase):
                     data["components"]["vhost1-queue1"]["status"], shovel_status
                 )
 
-    @patch("requests.get")
+    @patch(MOCK_TARGET)
     def test_rabbitmq_healthcheck_error(
         self,
         mock_get,
@@ -230,7 +233,7 @@ class HealthCheckTestCase(unittest.TestCase):
                 data["components"]["rabbitmq_server"]["status"], Status.DOWN.value
             )
 
-    @patch("requests.get")
+    @patch(MOCK_TARGET)
     def test_converter_healthcheck_error(
         self,
         mock_get,
@@ -254,7 +257,7 @@ class HealthCheckTestCase(unittest.TestCase):
             (Status.UNKNOWN.value, Status.DOWN.value, Status.DOWN.value),
         ]
     )
-    @patch("requests.get")
+    @patch(MOCK_TARGET)
     def test_converter_healthcheck_status(
         self,
         converter_status,
@@ -276,7 +279,7 @@ class HealthCheckTestCase(unittest.TestCase):
                     data["components"]["converter"]["status"], expected_converter_status
                 )
 
-    @patch("requests.get")
+    @patch(MOCK_TARGET)
     def test_annuaire_healthcheck_error(
         self,
         mock_get,
@@ -300,7 +303,7 @@ class HealthCheckTestCase(unittest.TestCase):
             (Status.UNKNOWN.value, Status.DOWN.value, Status.DOWN.value),
         ]
     )
-    @patch("requests.get")
+    @patch(MOCK_TARGET)
     def test_annuaire_healthcheck_status(
         self,
         annuaire_status,
@@ -325,20 +328,10 @@ class HealthCheckTestCase(unittest.TestCase):
     @parameterized.expand(
         [
             (
-                [
-                    {"status": "ok"},
-                    {"status": "UP", "components": {}},
-                    {"status": "UP", "components": {}},
-                    {"status": "UP"},
-                    {"status": "UP"},
-                    [
-                        {
-                            "vhost": "vhost1",
-                            "src_queue": "queue1",
-                            "blocked_status": "running",
-                        },
-                    ],
-                ],
+                {"status": "UP", "components": {}},
+                {"status": "UP", "components": {}},
+                {"status": "UP"},
+                {"status": "UP"},
                 "UP",
                 "UP",
                 "UP",
@@ -348,20 +341,10 @@ class HealthCheckTestCase(unittest.TestCase):
                 "UP",
             ),
             (
-                [
-                    {"status": "ok"},
-                    {"status": "UP", "components": {}},
-                    {"status": "DOWN", "components": {}},
-                    {"status": "DOWN"},
-                    {"status": "DOWN"},
-                    [
-                        {
-                            "vhost": "vhost1",
-                            "src_queue": "queue1",
-                            "blocked_status": "running",
-                        },
-                    ],
-                ],
+                {"status": "UP", "components": {}},
+                {"status": "DOWN", "components": {}},
+                {"status": "DOWN"},
+                {"status": "DOWN"},
                 "DOWN",
                 "UP",
                 "UP",
@@ -372,10 +355,13 @@ class HealthCheckTestCase(unittest.TestCase):
             ),
         ]
     )
-    @patch("requests.get")
+    @patch(MOCK_TARGET)
     def test_health_check_with_multiple_dispatchers(
         self,
-        side_effect,
+        dispatcher1_response,
+        dispatcher2_response,
+        converter_response,
+        annuaire_response,
         global_status,
         rabbitmq_status,
         dispatcher1_status,
@@ -385,11 +371,30 @@ class HealthCheckTestCase(unittest.TestCase):
         shovel_status,
         mock_get,
     ):
-        mock_get.return_value.status_code = 200
-        mock_get.return_value.json.side_effect = side_effect
+        dispatcher1_name = "dispatcher1"
+        dispatcher2_name = "dispatcher2"
+
+        dispatcher_responses = {
+            dispatcher1_name: dispatcher1_response,
+            dispatcher2_name: dispatcher2_response,
+        }
+
+        def side_effect(url, **kwargs):
+            for name, resp_data in dispatcher_responses.items():
+                if name in url:
+                    mock_response = requests.Response()
+                    mock_response.status_code = 200
+                    mock_response._content = json.dumps(resp_data).encode()
+                    return mock_response
+            return self.create_mock_side_effect(
+                converter_response=converter_response,
+                annuaire_response=annuaire_response,
+            )(url, **kwargs)
+
+        mock_get.side_effect = side_effect
 
         with patch(
-            "checks.dispatcher.DISPATCHER_INSTANCES", ["dispatcher1", "dispatcher2"]
+            "checks.dispatcher.DISPATCHER_INSTANCES", [dispatcher1_name, dispatcher2_name]
         ):
             with app.test_client() as client:
                 response = client.get(HEALTH_INTERNAL_ENDPOINT)
@@ -400,10 +405,10 @@ class HealthCheckTestCase(unittest.TestCase):
                     data["components"]["rabbitmq_server"]["status"], rabbitmq_status
                 )
                 self.assertEqual(
-                    data["components"]["dispatcher1"]["status"], dispatcher1_status
+                    data["components"][dispatcher1_name]["status"], dispatcher1_status
                 )
                 self.assertEqual(
-                    data["components"]["dispatcher2"]["status"], dispatcher2_status
+                    data["components"][dispatcher2_name]["status"], dispatcher2_status
                 )
                 self.assertEqual(
                     data["components"]["converter"]["status"], converter_status
@@ -415,7 +420,7 @@ class HealthCheckTestCase(unittest.TestCase):
                     data["components"]["vhost1-queue1"]["status"], shovel_status
                 )
 
-    @patch("requests.get")
+    @patch(MOCK_TARGET)
     def test_external_health_check(
         self,
         mock_get,
@@ -444,13 +449,12 @@ class HealthCheckTestCase(unittest.TestCase):
                 )
                 self.assertNotIn("annuaire", data["components"].keys())
 
-    @patch("requests.get")
+    @patch(MOCK_TARGET)
     def test_update_metrics_before_scrapping_requests_are_made(
         self,
         mock_get,
     ):
-        mock_get.return_value.status_code = 200
-        mock_get.return_value.json.return_value = {"status": Status.UP.value}
+        mock_get.side_effect = self.create_mock_side_effect()
 
         with patch(
             "checks.dispatcher.DISPATCHER_INSTANCES", ["dispatcher1", "dispatcher2"]

--- a/tools/healthcheck/tests/test_hubex_partners_shovels.py
+++ b/tools/healthcheck/tests/test_hubex_partners_shovels.py
@@ -90,7 +90,7 @@ class TestFunctionalHubexPartnersShovels(unittest.TestCase):
         new_callable=mock_open,
         read_data="vhost1;queue1\n",
     )
-    @patch("checks.hubex_partners_shovels.requests.get")
+    @patch("http_client.http_session.get")
     def test_metric_set_to_1_on_success(self, mock_get, mock_file):
         # Mock the response from requests.get
         mock_response = MagicMock()
@@ -131,7 +131,7 @@ class TestFunctionalHubexPartnersShovels(unittest.TestCase):
         new_callable=mock_open,
         read_data="vhost1;queue1,queue2\n",
     )
-    @patch("checks.hubex_partners_shovels.requests.get")
+    @patch("http_client.http_session.get")
     def test_status_up_for_healthy_components_when_a_failure_occurs(
         self, mock_get, mock_file
     ):


### PR DESCRIPTION
## 🔎 Détails

Des alertes sont de temps en temps remontées indiquant que le composant healthcheck est `down` alors que celui tourne bien.
Après investigation, cette alerte résulte d'une incapacité du service à répondre à prometheus en moins de 10s sur l'endpoint `/metrics` (le service monitor associé défini un scapeTimeout à 10 secondes).
Dans le code du healthcheck, les vérifications des status sont réalisées de manière séquentielle en itérant sur une liste de `checker`. En cas de timeout (défini à 5 secondes par défaut via la variable `HTPP_TIMEOUT`), l'application peut mettre plus de 10 secondes à répondre et voir son status passé à down pour prometheus.
Pour fixer ce problème, on peut lancer les différents checks en parallèle (et non de manière séquentielle par le biais d'un `TheadPoolExecutor`.

## 📄 Documentation

[Contre mesure déterminée suite à l'indisponibilité du 03/04/2026](https://ans-esante.atlassian.net/wiki/spaces/HUB/pages/1747419137/Indispo+converter+rabbitmq+dispatcher+le+03+04+2026#Contre-mesure)

## 📸 Captures d'écran

| Avant | Après |
| ----- | ----- |
| <img width="1120" height="120" alt="Capture d’écran 2026-04-09 à 12 20 01" src="https://github.com/user-attachments/assets/1935be0b-0fd1-492c-849d-1b5d844348e0" /> | <img width="1127" height="439" alt="Capture d’écran 2026-04-09 à 12 17 06" src="https://github.com/user-attachments/assets/756ad8f8-6746-49f6-b8e3-8cd0e42870e5" /> |
| <img width="442" height="72" alt="Capture d’écran 2026-04-09 à 12 22 10" src="https://github.com/user-attachments/assets/e0b89d39-abbc-4d3f-8a65-f3273d16562e" /> | <img width="536" height="402" alt="Capture d’écran 2026-04-09 à 12 21 47" src="https://github.com/user-attachments/assets/24de248d-40bf-4de6-8a49-d3e4a173dd5b" /> |

## 🔗Ticket associé

[Asana]()
