### PR TITLE
Feat/tnr : Scénario de test e2e couvrant les messages RS-RI et RS-SR pour flux 15 → 18

### DIFF
--- a/tools/tnr/src/main/java/tnr/MessageType.java
+++ b/tools/tnr/src/main/java/tnr/MessageType.java
@@ -4,6 +4,7 @@ public enum MessageType {
     CREATE_CASE("createCase"),
     CREATE_CASE_HEALTH("createCaseHealth"),
     RESOURCES_INFO("resourcesInfo"),
+    RESOURCES_INFO_CISU("resourcesInfoCisu"),
     RESOURCES_STATUS("resourcesStatus");
 
     private final String value;

--- a/tools/tnr/src/main/java/tnr/Utils.java
+++ b/tools/tnr/src/main/java/tnr/Utils.java
@@ -3,6 +3,7 @@ package tnr;
 import java.util.Arrays;
 import java.util.UUID;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import tnr.dto.MessageDTO;
 
 public class Utils {
@@ -18,41 +19,32 @@ public class Utils {
         return String.join(".", Arrays.copyOfRange(parts, 2, parts.length));
     }
 
-    public static boolean isMessageOfType(MessageDTO message, MessageType type) {
-        if(message.isXML()){
+    public static JsonNode getMessageNode(MessageDTO message) {
+        if (message.isXML()) {
             return message.getPayload()
                     .path("content")
                     .path("contentObject")
                     .path("contentXML")
                     .path("embeddedXMLContent")
-                    .path("message")
-                    .has(type.value());
+                    .path("message");
         }
         return message.getPayload()
                 .path("content").path(0)
                 .path("jsonContent")
                 .path("embeddedJsonContent")
-                .path("message")
-                .has(type.value());
+                .path("message");
+    }
+
+    public static JsonNode getUseCaseNode(MessageDTO message, MessageType type) {
+        return getMessageNode(message).path(type.value());
+    }
+
+    public static boolean isMessageOfType(MessageDTO message, MessageType type) {
+        return getMessageNode(message).has(type.value());
     }
 
     public static String getReferencedDistributionID(MessageDTO message) {
-        if(message.isXML()){
-            return  message.getPayload()
-                    .path("content")
-                    .path("contentObject")
-                    .path("contentXML")
-                    .path("embeddedXMLContent")
-                    .path("message")
-                    .path("reference")
-                    .path("distributionID")
-                    .asText(null);
-        }
-        return message.getPayload()
-                .path("content").path(0)
-                .path("jsonContent")
-                .path("embeddedJsonContent")
-                .path("message")
+        return getMessageNode(message)
                 .path("reference")
                 .path("distributionID")
                 .asText(null);

--- a/tools/tnr/src/test/java/tnr/DistributionAssertions.java
+++ b/tools/tnr/src/test/java/tnr/DistributionAssertions.java
@@ -44,6 +44,13 @@ public final class DistributionAssertions {
                 "Expected message type '%s'".formatted(MessageType.RESOURCES_INFO));
     }
 
+    public static void assertAck(MessageDTO matchedAck, String ackDistributionId, String expectedVhost, String expectedQueue, String expectedReferencedDistributionId) {
+        assertNotNull(matchedAck, "Ack " + ackDistributionId + " not received within " + RECEIVE_TIMEOUT_SECS + "s");
+        assertVhostEquals(matchedAck, expectedVhost);
+        assertQueueEquals(matchedAck, expectedQueue);
+        assertEquals(expectedReferencedDistributionId, Utils.getReferencedDistributionID(matchedAck));
+    }
+
     public static void assertRsSr(List<MessageDTO> messages, String expectedCaseId, Set<String> expectedResourceIds) {
         Set<String> received = new HashSet<>();
         for (MessageDTO rsSr : messages) {

--- a/tools/tnr/src/test/java/tnr/DistributionAssertions.java
+++ b/tools/tnr/src/test/java/tnr/DistributionAssertions.java
@@ -53,12 +53,10 @@ public final class DistributionAssertions {
     }
 
     public static void assertRcRiResourceVehicleType(MessageDTO rcRi, String expectedVehicleType) {
-        JsonNode rcRiNode = rcRi.getPayload()
-                .path("content").path(0)
-                .path("jsonContent").path("embeddedJsonContent").path("message")
-                .path(MessageType.RESOURCES_INFO_CISU.value());
-        assertEquals(expectedVehicleType, rcRiNode.path("resource").path(0).path("vehicleType").asText(),
-                "RC-RI vehicle type mismatch (transcoding check)");
+        JsonNode rcRiNode = Utils.getUseCaseNode(rcRi, MessageType.RESOURCES_INFO_CISU);
+        JsonNode resourceNode = rcRiNode.path("resource");
+        JsonNode firstResource = resourceNode.isArray() ? resourceNode.path(0) : resourceNode;
+        assertEquals(expectedVehicleType, firstResource.path("vehicleType").asText(), "RC-RI vehicle type mismatch (transcoding check)");
     }
 
     public static void assertAck(MessageDTO matchedAck, String ackDistributionId, String expectedVhost, String expectedQueue, String expectedReferencedDistributionId) {
@@ -74,12 +72,8 @@ public final class DistributionAssertions {
             assertNotNull(rsSr, "RS-SR not received within " + RECEIVE_TIMEOUT_SECS + "s");
             assertVhostEquals(rsSr, VHOST_15_15_V3_TAG);
             assertQueueEquals(rsSr, SAMU1_V3_ID + ".message");
-            assertTrue(Utils.isMessageOfType(rsSr, MessageType.RESOURCES_STATUS),
-                    "Expected message type '%s'".formatted(MessageType.RESOURCES_STATUS));
-            JsonNode rsNode = rsSr.getPayload()
-                    .path("content").path(0)
-                    .path("jsonContent").path("embeddedJsonContent").path("message")
-                    .path(MessageType.RESOURCES_STATUS.value());
+            assertTrue(Utils.isMessageOfType(rsSr, MessageType.RESOURCES_STATUS), "Expected message type '%s'".formatted(MessageType.RESOURCES_STATUS));
+            JsonNode rsNode = Utils.getUseCaseNode(rsSr, MessageType.RESOURCES_STATUS);
             assertEquals(expectedCaseId, rsNode.path("caseId").asText(), "RS-SR caseId mismatch");
             assertFalse(rsNode.has("position"), "RS-SR should not contain a 'position' field (transcoding suppression)");
             received.add(rsNode.path("resourceId").asText());

--- a/tools/tnr/src/test/java/tnr/DistributionAssertions.java
+++ b/tools/tnr/src/test/java/tnr/DistributionAssertions.java
@@ -44,6 +44,23 @@ public final class DistributionAssertions {
                 "Expected message type '%s'".formatted(MessageType.RESOURCES_INFO));
     }
 
+    public static void assertRcRi(MessageDTO rcRi, String distributionId) {
+        assertNotNull(rcRi, "RC-RI " + distributionId + " not received within " + RECEIVE_TIMEOUT_SECS + "s");
+        assertVhostEquals(rcRi, VHOST_15_NEXSIS_V3_TAG);
+        assertQueueEquals(rcRi, HUB_NEXSIS_USER_CLIENT_ID + ".message");
+        assertTrue(Utils.isMessageOfType(rcRi, MessageType.RESOURCES_INFO_CISU),
+                "Expected message type '%s'".formatted(MessageType.RESOURCES_INFO_CISU));
+    }
+
+    public static void assertRcRiResourceVehicleType(MessageDTO rcRi, String expectedVehicleType) {
+        JsonNode rcRiNode = rcRi.getPayload()
+                .path("content").path(0)
+                .path("jsonContent").path("embeddedJsonContent").path("message")
+                .path(MessageType.RESOURCES_INFO_CISU.value());
+        assertEquals(expectedVehicleType, rcRiNode.path("resource").path(0).path("vehicleType").asText(),
+                "RC-RI vehicle type mismatch (transcoding check)");
+    }
+
     public static void assertAck(MessageDTO matchedAck, String ackDistributionId, String expectedVhost, String expectedQueue, String expectedReferencedDistributionId) {
         assertNotNull(matchedAck, "Ack " + ackDistributionId + " not received within " + RECEIVE_TIMEOUT_SECS + "s");
         assertVhostEquals(matchedAck, expectedVhost);

--- a/tools/tnr/src/test/java/tnr/SamuFireTest.java
+++ b/tools/tnr/src/test/java/tnr/SamuFireTest.java
@@ -277,4 +277,66 @@ class SamuFireTest extends AMQPTestSupport {
         assertAck(matchedAck, ackDistributionId, VHOST_15_NEXSIS_V3_TAG, HUB_NEXSIS_USER_CLIENT_ID + ".ack", referencedDistributionId);
     }
 
+    @Test
+    @DisplayName("RS-RI then RS-SR lifecycle (Alice & Grégoire NORMAND): SMUR resource engagement with status, then status update (tests n°2–3)")
+    void rsRiWithStatusThenRsSrNormandLifecycle() throws Exception {
+
+        String uniqueCaseId = "fr.health.tnr.test." + UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+
+        // Test n°2: RS-RI with SMUR resource and status → RC-RI with transcoded vehicle type
+        String step2DistId = sendSamuMessage(RS_RI_NORMAND_REF, uniqueCaseId);
+        MessageDTO step2RcRi = awaitMessageByDistributionId(step2DistId);
+        assertRcRi(step2RcRi, step2DistId);
+        assertRcRiResourceVehicleType(step2RcRi, "SMUR");
+        sendAndAssertAckFromNexsis(step2DistId);
+
+        // Test n°3: RS-SR status update → RC-RI (distributionId from persisted RS-RI envelope)
+        sendSamuMessage(RS_SR_NORMAND_REF, uniqueCaseId);
+        MessageDTO step3RcRi = awaitMessageOfType(MessageType.RESOURCES_INFO_CISU);
+        assertRcRi(step3RcRi, step3RcRi.getDistributionId());
+        sendAndAssertAckFromNexsis(step3RcRi.getDistributionId());
+    }
+
+    @Test
+    @DisplayName("RS-RI without status then RS-SR lifecycle (Robert VERMANDE): resource without status ignored, then RC-RI on status addition (tests n°6–7)")
+    void rsRiWithoutStatusThenRsSrVermandeLifecycle() throws Exception {
+
+        String uniqueCaseId = "fr.health.tnr.test." + UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+
+        // Test n°6: RS-RI without status → no output, no ack
+        sendSamuMessage(RS_RI_VERMANDE_REF, uniqueCaseId);
+        assertNoMessageReceived(msg -> msg.getQueue().equals(HUB_NEXSIS_USER_CLIENT_ID + ".message"));
+
+        // Test n°7: RS-SR adds status → RC-RI (distributionId from persisted RS-RI envelope)
+        sendSamuMessage(RS_SR_VERMANDE_REF, uniqueCaseId);
+        MessageDTO step7RcRi = awaitMessageOfType(MessageType.RESOURCES_INFO_CISU);
+        assertRcRi(step7RcRi, step7RcRi.getDistributionId());
+        sendAndAssertAckFromNexsis(step7RcRi.getDistributionId());
+    }
+
+    @Test
+    @DisplayName("RS-RI non-SMUR resource ignored (Monsieur X): TSU resource with status produces no output (test n°8)")
+    void rsRiNonSmurResourceIgnored() throws Exception {
+
+        String uniqueCaseId = "fr.health.tnr.test." + UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+
+        sendSamuMessage(RS_RI_MONSIEUR_X_REF, uniqueCaseId);
+        assertNoMessageReceived(msg -> msg.getQueue().equals(HUB_NEXSIS_USER_CLIENT_ID + ".message"));
+    }
+
+    private String sendSamuMessage(String fixtureRef, String caseId) throws Exception {
+        String useCase = getUseCaseContentOnline(V3_SAMU_TAG, fixtureRef)
+                .replaceFirst("\"caseId\"\\s*:\\s*\"[^\"]+\"", "\"caseId\": \"" + caseId + "\"");
+        String distributionId = Utils.generateDistributionId(SAMU1_V3_ID);
+        sendMessage(VHOST_15_15_V3_TAG, SAMU1_V3_ID,
+                new MessageBuilder().buildMessage(useCase, distributionId, SAMU1_V3_ID, TNR_SDIS_CLIENT_ID));
+        return distributionId;
+    }
+
+    private void sendAndAssertAckFromNexsis(String referencedDistributionId) throws Exception {
+        String ackDistributionId = sendAck(VHOST_15_NEXSIS_V3_TAG, NEXSIS_SHOVEL_ROUTING_KEY, SAMU1_V3_ID, referencedDistributionId);
+        MessageDTO matchedAck = awaitMessageByDistributionId(ackDistributionId);
+        assertAck(matchedAck, ackDistributionId, VHOST_15_15_V3_TAG, SAMU1_V3_ID + ".ack", referencedDistributionId);
+    }
+
 }

--- a/tools/tnr/src/test/java/tnr/SamuFireTest.java
+++ b/tools/tnr/src/test/java/tnr/SamuFireTest.java
@@ -274,10 +274,7 @@ class SamuFireTest extends AMQPTestSupport {
     private void sendAndAssertAck(String referencedDistributionId) throws Exception {
         String ackDistributionId = sendAck(VHOST_15_15_V3_TAG, SAMU1_V3_ID, TNR_SDIS_CLIENT_ID, referencedDistributionId);
         MessageDTO matchedAck = awaitMessageByDistributionId(ackDistributionId);
-        assertNotNull(matchedAck, "Ack " + ackDistributionId + " not received within " + RECEIVE_TIMEOUT_SECS + "s");
-        assertVhostEquals(matchedAck, VHOST_15_NEXSIS_V3_TAG);
-        assertQueueEquals(matchedAck, HUB_NEXSIS_USER_CLIENT_ID + ".ack");
-        assertEquals(referencedDistributionId, Utils.getReferencedDistributionID(matchedAck));
+        assertAck(matchedAck, ackDistributionId, VHOST_15_NEXSIS_V3_TAG, HUB_NEXSIS_USER_CLIENT_ID + ".ack", referencedDistributionId);
     }
 
 }

--- a/tools/tnr/src/test/java/tnr/TestConstants.java
+++ b/tools/tnr/src/test/java/tnr/TestConstants.java
@@ -50,4 +50,19 @@ public final class TestConstants {
     public static final String RC_RI_RESOURCE_ID  = "fr.fire.sisXXX.cga-XXX.resource.VSR268";
     public static final String RC_RI_RESOURCE2_ID = "fr.fire.sisXXX.cga-XXX.resource.VSAV1";
     public static final String RC_RI_RESOURCE3_ID = "fr.fire.sisXXX.cga-XXX.resource.VSAV2";
+
+    // Use case references — RS-RI/RS-SR (Alice & Grégoire NORMAND FuiteDeGaz lifecycle)
+    public static final String RS_RI_NORMAND_REF = "RS-RI/RS-RI_FuiteDeGaz_AliceGregoireNORMAND.03.json"; // SMUR resource with status
+    public static final String RS_SR_NORMAND_REF = "RS-SR/RS-SR_FuiteDeGaz_AliceGregoireNORMAND.04.json"; // status update
+
+    // Use case references — RS-RI/RS-SR (Robert VERMANDE lifecycle)
+    public static final String RS_RI_VERMANDE_REF = "RS-RI/RS-RI_Secondaire_RobertVermande.03.json"; // SMUR resource without status
+    public static final String RS_SR_VERMANDE_REF = "RS-SR/RS-SR_Secondaire_RobertVermande.06.json"; // adds status
+
+    // Use case references — RS-RI (Monsieur X non-SMUR)
+    public static final String RS_RI_MONSIEUR_X_REF = "RS-RI/RS-RI_partageRessources_MonsieurX.03.json"; // TSU resource with status
+
+    // Resource IDs — RS-RI
+    public static final String RS_RI_NORMAND_RESOURCE_ID  = "fr.health.samu440.resource.VLM2";
+    public static final String RS_RI_VERMANDE_RESOURCE_ID = "fr.health.samu680.resource.AR1";
 }


### PR DESCRIPTION
## 🔎 Détails

Cette PR ajoute les TNR automatiques pour le cycle de vie RS-RI / RS-SR côté SAMU émetteur (NexSIS destinataire), conformément aux cas de test n°2, 3, 6, 7 et 8 du [cahier de recette](https://ans-esante.atlassian.net/wiki/spaces/HUB/pages/1688961025/Tests+QA+Message+unique+RC-RI#Sens-15-%E2%86%92-18).

**Nouveaux tests** (SamuFireTest.java) :
- **Test n°2–3 — NORMAND** : envoi d'un RS-RI avec ressource SMUR engagée et statut → attente d'un RC-RI avec vérification du transcodage du `vehicleType` (`SMUR.VLM` → `SMUR`) ; puis envoi d'un RS-SR de mise à jour de statut → attente d'un nouveau RC-RI.
- **Test n°6–7 — VERMANDE** : envoi d'un RS-RI sans statut → vérification qu'aucun RC-RI n'est produit ; puis envoi d'un RS-SR ajoutant un statut → attente d'un RC-RI.
- **Test n°8 — Monsieur X** : envoi d'un RS-RI avec ressource TSU (non-SMUR) → vérification qu'aucun RC-RI n'est produit.

**Refactoring** (SamuFireTest.java) :
- `sendAndAssertAck` découpé en `sendAck` + assertion séparée, permettant la réutilisation pour les deux sens (SAMU→NexSIS et NexSIS→SAMU).
- Ajout de `sendSamuMessage` et `sendAndAssertAckFromNexsis` comme helpers internes.

### Points d'attentions

#### 1. Bug converter 2.7.0-rc.2 → mise à jour vers 2.7.0-rc.3 requise

La version converter-2.7.0-rc.2 initialement déployée contenait un bug dans ResourcesStatusConverter.from_rs_to_cisu : l'appel set_value écrivait le contenu à un mauvais niveau dans l'enveloppe EDXL, produisant un RC-RI malformé.

Fix : déploiement de converter-2.7.0-rc.3 qui corrige ce bug.

#### 2. Payload reçu en XML, pas en JSON

Les messages RC-RI destinés à `fr.health.fire` sont envoyés par le dispatcher `15-nexsis_v1.9` en **XML**. Le consumer TNR détecte le `content-type: application/xml` et parse avec `xmlMapper`, produisant une structure différente de JSON :

| Format | Chemin vers le contenu métier |
|--------|-------------------------------|
| JSON   | `content[0].jsonContent.embeddedJsonContent.message` |
| XML    | `content.contentObject.contentXML.embeddedXMLContent.message` |

Les assertions qui naviguaient le payload avec le chemin JSON en dur échouaient silencieusement (`MissingNode`).

**Fix** : ajout de `Utils.getMessageNode(MessageDTO)` qui abstrait les deux chemins, factorisant également `isMessageOfType` et `getReferencedDistributionID` qui dupliquaient cette logique. `DistributionAssertions` utilise désormais `Utils.getUseCaseNode`.


## 📄 Documentation

> Ajoutez un (des) lien(s) vers la documentation si nécessaire

## 📸 Captures d'écran

| Avant | Après |
| ----- | ----- |
|       |       |

## 🔗Ticket associé

[Ecrire les tests liés au messages unique (Flux 15 → 18)](https://app.asana.com/1/1201445755223134/project/1213699865754209/task/1213919437639081?focus=true)

## ✅ A vérifier

- [ ] J'ai exécuté les tests e2e du LRM client localement, s'il a été modifié
