### PR TITLE
feat (healthcheck): move mongo client instantiation into check

### DIFF
--- a/tools/healthcheck/checks/mongo.py
+++ b/tools/healthcheck/checks/mongo.py
@@ -3,13 +3,15 @@ from prometheus_client import Gauge
 from checks.checker import IChecker
 from checks.status import Status
 
-from mongo_client import mongo_client
+from pymongo import MongoClient
+from config import MONGODB_URI, HTTP_TIMEOUT
 
 
 class MongoDBHealthcheck(IChecker):
     mongodb_status_metric = Gauge("mongodb_status", "Statut de MongoDB (1=UP, 0=DOWN)")
 
     def perform_checks(self):
+        mongo_client = MongoClient(MONGODB_URI, timeoutMS=HTTP_TIMEOUT * 1000)
         mongo_client.admin.command("ping")
 
         self.mongodb_status_metric.set(1)

--- a/tools/healthcheck/mongo_client.py
+++ b/tools/healthcheck/mongo_client.py
@@ -1,4 +1,0 @@
-from pymongo import MongoClient
-from config import MONGODB_URI, HTTP_TIMEOUT
-
-mongo_client = MongoClient(MONGODB_URI, timeoutMS=HTTP_TIMEOUT * 1000)

--- a/tools/healthcheck/tests/test_healthcheck.py
+++ b/tools/healthcheck/tests/test_healthcheck.py
@@ -16,7 +16,7 @@ with patch("checks.hubex_partners_shovels.open", mock_open(read_data="vhost1;que
 MOCK_TARGET = "http_client.http_session.get"
 
 
-@patch("checks.mongo.mongo_client")
+@patch("checks.mongo.MongoClient")
 class HealthCheckTestCase(unittest.TestCase):
     def setUp(self):
         # Prevent logging errors when the mocks throw exceptions.
@@ -524,7 +524,10 @@ class HealthCheckTestCase(unittest.TestCase):
                 self.assertEqual(
                     data["components"]["mongodb"]["status"], Status.UP.value
                 )
-                mock_mongo_client.admin.command.assert_called_with("ping")
+                self.assertEqual(
+                    mock_mongo_client.return_value.admin.command.called, True
+                )
+                mock_mongo_client.return_value.admin.command.assert_called_with("ping")
 
     @patch("requests.get")
     def test_mongodb_healthcheck_error(
@@ -533,7 +536,7 @@ class HealthCheckTestCase(unittest.TestCase):
         mock_mongo_client,
     ):
         mock_get.side_effect = self.create_mock_side_effect()
-        mock_mongo_client.admin.command.side_effect = Exception("MongoDB Error")
+        mock_mongo_client.return_value.admin.command.side_effect = Exception("MongoDB Error")
 
         with patch("checks.dispatcher.DISPATCHER_INSTANCES", ["dispatcher_instance"]):
             with app.test_client() as client:

--- a/tools/healthcheck/tests/test_healthcheck.py
+++ b/tools/healthcheck/tests/test_healthcheck.py
@@ -536,7 +536,9 @@ class HealthCheckTestCase(unittest.TestCase):
         mock_mongo_client,
     ):
         mock_get.side_effect = self.create_mock_side_effect()
-        mock_mongo_client.return_value.admin.command.side_effect = Exception("MongoDB Error")
+        mock_mongo_client.return_value.admin.command.side_effect = Exception(
+            "MongoDB Error"
+        )
 
         with patch("checks.dispatcher.DISPATCHER_INSTANCES", ["dispatcher_instance"]):
             with app.test_client() as client:

--- a/tools/healthcheck/tests/test_mongo.py
+++ b/tools/healthcheck/tests/test_mongo.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 import logging
 
 from checks.mongo import MongoDBHealthcheck
@@ -7,44 +7,41 @@ from checks.status import Status
 
 
 class TestMongoDBHealthcheck(unittest.TestCase):
-    @patch("checks.mongo.mongo_client")
+    @patch("checks.mongo.MongoClient")
     def test_perform_checks_success(self, mock_mongo_client):
-        # Mock successful ping
-        mock_mongo_client.admin.command.return_value = {"ok": 1}
+        mock_instance = MagicMock()
+        mock_instance.admin.command.return_value = {"ok": 1}
+        mock_mongo_client.return_value = mock_instance
 
         checker = MongoDBHealthcheck()
         result = checker.perform_checks()
 
-        # Check response
         self.assertEqual(result, {"mongodb": {"status": Status.UP.value}})
 
-        # Check metric
         metric = checker.mongodb_status_metric
         samples = metric.collect()[0].samples
         self.assertTrue(samples, "No metric samples found")
         self.assertEqual(samples[0].value, 1.0)
 
-    @patch("checks.mongo.mongo_client")
+    @patch("checks.mongo.MongoClient")
     def test_perform_checks_failure(self, mock_mongo_client):
-        # Simulate failure
-        mock_mongo_client.admin.command.side_effect = Exception("Mongo down")
+        mock_instance = MagicMock()
+        mock_instance.admin.command.side_effect = Exception("Mongo down")
+        mock_mongo_client.return_value = mock_instance
 
         checker = MongoDBHealthcheck()
 
-        # perform_checks should raise → handled by wrapper normally
         with self.assertRaises(Exception):
             checker.perform_checks()
 
-    @patch("checks.mongo.mongo_client")
+    @patch("checks.mongo.MongoClient")
     def test_check_failure_fallback(self, mock_mongo_client):
         checker = MongoDBHealthcheck()
 
         result = checker.check_failure_fallback()
 
-        # Check response
         self.assertEqual(result, {"mongodb": {"status": Status.DOWN.value}})
 
-        # Check metric
         metric = checker.mongodb_status_metric
         samples = metric.collect()[0].samples
         self.assertTrue(samples, "No metric samples found")
@@ -53,37 +50,36 @@ class TestMongoDBHealthcheck(unittest.TestCase):
 
 class TestFunctionalMongoDBHealthcheck(unittest.TestCase):
     def setUp(self):
-        # Disable logging noise like in existing tests
         logging.disable(logging.CRITICAL)
 
     def tearDown(self):
         logging.disable(logging.NOTSET)
 
-    @patch("checks.mongo.mongo_client")
+    @patch("checks.mongo.MongoClient")
     def test_wrapper_success_sets_metric_to_1(self, mock_mongo_client):
-        mock_mongo_client.admin.command.return_value = {"ok": 1}
+        mock_instance = MagicMock()
+        mock_instance.admin.command.return_value = {"ok": 1}
+        mock_mongo_client.return_value = mock_instance
 
         checker = MongoDBHealthcheck()
         result = checker.check_wrapper()
 
-        # Check response
         self.assertEqual(result, {"mongodb": {"status": Status.UP.value}})
 
-        # Check metric
         samples = checker.mongodb_status_metric.collect()[0].samples
         self.assertEqual(samples[0].value, 1.0)
 
-    @patch("checks.mongo.mongo_client")
+    @patch("checks.mongo.MongoClient")
     def test_wrapper_failure_sets_metric_to_0(self, mock_mongo_client):
-        mock_mongo_client.admin.command.side_effect = Exception("Mongo down")
+        mock_instance = MagicMock()
+        mock_instance.admin.command.side_effect = Exception("Mongo down")
+        mock_mongo_client.return_value = mock_instance
 
         checker = MongoDBHealthcheck()
         result = checker.check_wrapper()
 
-        # Check response
         self.assertEqual(result, {"mongodb": {"status": Status.DOWN.value}})
 
-        # Check metric
         samples = checker.mongodb_status_metric.collect()[0].samples
         self.assertEqual(samples[0].value, 0.0)
 


### PR DESCRIPTION
## 🔎 Détails

Instanciation du mongo client à chaque check pour absorber toutes les erreurs potentielles dans le failback


## 🔗Ticket associé

[fix healthcheck mongo](https://app.asana.com/1/1201445755223134/project/1213900980560885/task/1214131719880821)

