### PR TITLE
feat(LRM): ajout de l’acquittement refusé dans le LRM de test

### DIFF
--- a/web/lrm/client/components/ReceivedMessage.vue
+++ b/web/lrm/client/components/ReceivedMessage.vue
@@ -227,7 +227,6 @@ const sendAck = (refused = false) => {
   }
 };
 
-
 //on mounted, send ack if autoAckConfig is enabled
 onMounted(() => {
   if (autoAckConfig.value) {

--- a/web/lrm/client/components/ReceivedMessage.vue
+++ b/web/lrm/client/components/ReceivedMessage.vue
@@ -68,8 +68,7 @@
               variant="text"
               size="x-small"
               :color="acked ? 'accent' : 'primary'"
-              :disabled="!!acked"
-              @click="sendAck"
+              @click="sendAck()"
             >
               <v-icon size="24">mdi-check-all</v-icon>
             </v-btn>
@@ -78,8 +77,7 @@
               variant="text"
               size="x-small"
               :color="acked ? 'accent' : 'error'"
-              :disabled="!!acked"
-              @click="sendRefusedAck"
+              @click="sendAck(true)"
             >
               <v-icon size="24">mdi-close-circle</v-icon>
             </v-btn>
@@ -210,19 +208,18 @@ const acked = computed(() => {
     );
 });
 
-
-const sendAck = () => {
+const sendAck = (refused = false) => {
   try {
     const distributionID = props.body.distributionID;
     const senderID = props.body.senderID;
-    if (getMessageType({ body: props.body }) !== 'message') {
-      return;
-    }
+
+    if (getMessageType({ body: props.body }) !== 'message') return;
+
     if (senderID.includes(INTERNAL_HUB_USER)) {
       consola.warn(`Ack not sent: ${INTERNAL_HUB_USER} is not a valid client`);
       return;
     }
-    const msg = buildAck({ distributionID, senderID });
+    const msg = buildAck({ distributionID, senderID, refused });
     sendMessage(msg, props.vhost);
     isAcked.value = true;
   } catch (error) {
@@ -230,29 +227,6 @@ const sendAck = () => {
   }
 };
 
-const sendRefusedAck = () => {
-  try {
-    const distributionID = props.body.distributionID;
-    const senderID = props.body.senderID;
-
-    if (getMessageType({ body: props.body }) !== 'message') {
-      return;
-    }
-
-    if (senderID.includes(INTERNAL_HUB_USER)) {
-      consola.warn(
-        `Refused ack not sent: ${INTERNAL_HUB_USER} is not a valid client`
-      );
-      return;
-    }
-
-    const msg = buildAck({ distributionID, senderID, refused: true });
-    sendMessage(msg, props.vhost);
-    isAcked.value = true;
-  } catch (error) {
-    consola.error("Erreur lors de l'envoi de l'acquittement refusé", error);
-  }
-};
 
 //on mounted, send ack if autoAckConfig is enabled
 onMounted(() => {

--- a/web/lrm/client/components/ReceivedMessage.vue
+++ b/web/lrm/client/components/ReceivedMessage.vue
@@ -68,9 +68,20 @@
               variant="text"
               size="x-small"
               :color="acked ? 'accent' : 'primary'"
+              :disabled="!!acked"
               @click="sendAck"
             >
               <v-icon size="24">mdi-check-all</v-icon>
+            </v-btn>
+            <v-btn
+              icon
+              variant="text"
+              size="x-small"
+              :color="acked ? 'accent' : 'error'"
+              :disabled="!!acked"
+              @click="sendRefusedAck"
+            >
+              <v-icon size="24">mdi-close-circle</v-icon>
             </v-btn>
           </div>
           <v-btn
@@ -199,6 +210,7 @@ const acked = computed(() => {
     );
 });
 
+
 const sendAck = () => {
   try {
     const distributionID = props.body.distributionID;
@@ -215,6 +227,30 @@ const sendAck = () => {
     isAcked.value = true;
   } catch (error) {
     consola.error("Erreur lors de l'envoi de l'acquittement", error);
+  }
+};
+
+const sendRefusedAck = () => {
+  try {
+    const distributionID = props.body.distributionID;
+    const senderID = props.body.senderID;
+
+    if (getMessageType({ body: props.body }) !== 'message') {
+      return;
+    }
+
+    if (senderID.includes(INTERNAL_HUB_USER)) {
+      consola.warn(
+        `Refused ack not sent: ${INTERNAL_HUB_USER} is not a valid client`
+      );
+      return;
+    }
+
+    const msg = buildAck({ distributionID, senderID, refused: true });
+    sendMessage(msg, props.vhost);
+    isAcked.value = true;
+  } catch (error) {
+    consola.error("Erreur lors de l'envoi de l'acquittement refusé", error);
   }
 };
 

--- a/web/lrm/client/components/StatusBadge.vue
+++ b/web/lrm/client/components/StatusBadge.vue
@@ -1,8 +1,5 @@
 <template>
-  <v-badge
-    :color="getBadgeColor()"
-    :content="getBadgeWording()"
-  />
+  <v-badge :color="getBadgeColor()" :content="getBadgeWording()" />
 </template>
 
 <script>
@@ -38,8 +35,8 @@ export default {
     },
     isRefused() {
       return (
-        this.acked?.body?.content?.[0]?.jsonContent?.embeddedJsonContent?.message
-          ?.reference?.refused === true
+        this.acked?.body?.content?.[0]?.jsonContent?.embeddedJsonContent
+          ?.message?.reference?.refused === true
       );
     },
   },

--- a/web/lrm/client/components/StatusBadge.vue
+++ b/web/lrm/client/components/StatusBadge.vue
@@ -1,13 +1,13 @@
 <template>
   <v-badge
     v-if="isOut(direction)"
-    :color="acked ? 'green' : 'orange'"
-    :content="acked ? 'Acquitté' : 'En envoi'"
+    :color="acked ? (isRefused() ? 'red' : 'green') : 'orange'"
+    :content="acked ? (isRefused() ? 'Refusé' : 'Acquitté') : 'En envoi'"
   />
   <v-badge
     v-else
-    :color="acked ? 'green' : 'orange'"
-    :content="acked ? 'Acquitté' : 'Délivré'"
+    :color="acked ? (isRefused() ? 'red' : 'green') : 'orange'"
+    :content="acked ? (isRefused() ? 'Refusé' : 'Acquitté') : 'Délivré'"
   />
 </template>
 
@@ -34,6 +34,12 @@ export default {
     isOut(direction) {
       return direction === DIRECTIONS.OUT;
     },
+    isRefused() {
+      return (
+        this.acked?.body?.content?.[0]?.jsonContent?.embeddedJsonContent?.message
+        ?.reference?.refused === true
+      );
+      }
   },
 };
 </script>

--- a/web/lrm/client/components/StatusBadge.vue
+++ b/web/lrm/client/components/StatusBadge.vue
@@ -1,13 +1,7 @@
 <template>
   <v-badge
-    v-if="isOut(direction)"
-    :color="acked ? (isRefused() ? 'red' : 'green') : 'orange'"
-    :content="acked ? (isRefused() ? 'Refusé' : 'Acquitté') : 'En envoi'"
-  />
-  <v-badge
-    v-else
-    :color="acked ? (isRefused() ? 'red' : 'green') : 'orange'"
-    :content="acked ? (isRefused() ? 'Refusé' : 'Acquitté') : 'Délivré'"
+    :color="getBadgeColor()"
+    :content="getBadgeWording()"
   />
 </template>
 
@@ -31,15 +25,23 @@ export default {
     };
   },
   methods: {
-    isOut(direction) {
-      return direction === DIRECTIONS.OUT;
+    getBadgeColor() {
+      if (!this.acked) return 'orange';
+      if (this.isRefused()) return 'red';
+      return 'green';
+    },
+    getBadgeWording() {
+      if (!this.acked) {
+        return this.direction === DIRECTIONS.OUT ? 'En envoi' : 'Délivré';
+      }
+      return this.isRefused() ? 'Refusé' : 'Acquitté';
     },
     isRefused() {
       return (
         this.acked?.body?.content?.[0]?.jsonContent?.embeddedJsonContent?.message
-        ?.reference?.refused === true
+          ?.reference?.refused === true
       );
-      }
+    },
   },
 };
 </script>

--- a/web/lrm/client/composables/messageUtils.js
+++ b/web/lrm/client/composables/messageUtils.js
@@ -126,9 +126,9 @@ export function setCaseId(message, caseId, localCaseId) {
   }
 }
 
-export function buildAck({ distributionID, senderID }) {
+export function buildAck({ distributionID, senderID, refused = false }) {
   return buildMessage(
-    { reference: { distributionID } },
+    { reference: { distributionID, refused } },
     { distributionKind: 'Ack', recipientId: senderID }
   );
 }

--- a/web/lrm/client/composables/messageUtils.js
+++ b/web/lrm/client/composables/messageUtils.js
@@ -128,7 +128,7 @@ export function setCaseId(message, caseId, localCaseId) {
 
 export function buildAck({ distributionID, senderID, refused = false }) {
   return buildMessage(
-    { reference: { distributionID, refused } },
+    { reference: { distributionID, ...(refused && { refused }) } },
     { distributionKind: 'Ack', recipientId: senderID }
   );
 }


### PR DESCRIPTION
## 🔎 Détails

- Ajouter le bouton ❌ dans la vue
- Générer un acquittement avec :
  - refused : true
- Ajout du badge rouge "Refusé" sur le message dans la vue

## 📸 Captures d'écran
Avant
<img width="361" height="229" alt="image" src="https://github.com/user-attachments/assets/47a178b8-5447-4967-8ffe-4bcd4534cc5e" />
Après
<img width="382" height="208" alt="image" src="https://github.com/user-attachments/assets/f33adf47-71d0-4583-bd8c-e0e4f736d3a6" />
<img width="370" height="206" alt="image" src="https://github.com/user-attachments/assets/a9200604-60a3-4c60-9d55-5024adb36892" />
<img width="379" height="172" alt="image" src="https://github.com/user-attachments/assets/c9279bef-5b14-4632-b209-4045456e94ee" />

## 🔗Ticket associé

[Asana](https://app.asana.com/1/1201445755223134/project/1213900980560885/task/1214100215318323?focus=true)

