### PR TITLE
feat(healthcheck): allow for port as argument

### DIFF
--- a/tools/healthcheck/healthcheck.py
+++ b/tools/healthcheck/healthcheck.py
@@ -14,6 +14,7 @@ from checks.dispatcher import DispatchersHealthcheck
 from checks.annuaire import AnnuaireHealthcheck
 from checks.hubex_partners_shovels import HubexPartnersHealthcheck
 from checks.mongo import MongoDBHealthcheck
+import argparse
 
 app = Flask(__name__)
 metrics = PrometheusMetrics(app)
@@ -88,4 +89,7 @@ def health_internal():
 
 
 if __name__ == "__main__":
-    app.run(host=DEFAULT_FLASK_HOST, port=DEFAULT_FLASK_PORT)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--port", type=int, default=DEFAULT_FLASK_PORT)
+    args = parser.parse_args()
+    app.run(host=DEFAULT_FLASK_HOST, port=args.port)


### PR DESCRIPTION
## 🔎 Détails

Par défaut, le healthchecker tourne sur le port 8080. En setup local, le port 8080 est utilisé par le dispatcher-1, créant un conflit. 
Cette PR ajoute la possibilité de set le port à partir d'un argument en ligne de commande. Utile pour les PR à venir.

## 🔗Ticket associé

[Asana](https://app.asana.com/1/1201445755223134/project/1213900980560885/task/1214150419134070?focus=true)
