### PR TITLE
[ Dispatcher ] - [ DLQ ] - Envoi conditionnel d'un message d'erreur

### DIFF
--- a/hub/dispatcher/src/main/java/com/hubsante/hub/config/AmqpConfiguration.java
+++ b/hub/dispatcher/src/main/java/com/hubsante/hub/config/AmqpConfiguration.java
@@ -32,6 +32,7 @@ public class AmqpConfiguration {
     public static final String DISTRIBUTION_DLX = "distribution.dlx";
     public static final String DLQ_REASON = "x-first-death-reason";
     public static final String DLQ_EXPIRED_REASON = "expired";
+    public static final String DLQ_REJECTED_REASON = "rejected";
     public static final String ORIGINAL_ROUTING_KEY = "x-original-routing-key";
     public static final String DISPATCHER_CONNECTION_NAME = "dispatcher";
 

--- a/hub/dispatcher/src/main/java/com/hubsante/hub/config/AmqpConfiguration.java
+++ b/hub/dispatcher/src/main/java/com/hubsante/hub/config/AmqpConfiguration.java
@@ -31,6 +31,7 @@ public class AmqpConfiguration {
     public static final String DISPATCH_DLQ_NAME = "dispatch.dlq";
     public static final String DISTRIBUTION_DLX = "distribution.dlx";
     public static final String DLQ_REASON = "x-first-death-reason";
+    public static final String DLQ_EXPIRED_REASON = "expired";
     public static final String ORIGINAL_ROUTING_KEY = "x-original-routing-key";
     public static final String DISPATCHER_CONNECTION_NAME = "dispatcher";
 

--- a/hub/dispatcher/src/main/java/com/hubsante/hub/service/Dispatcher.java
+++ b/hub/dispatcher/src/main/java/com/hubsante/hub/service/Dispatcher.java
@@ -332,19 +332,27 @@ public class Dispatcher {
                 return;
             }
             EdxlMessage edxlMessage = messageHandler.extractMessage(message);
+            String dlqReason = message.getMessageProperties().getHeader(DLQ_REASON);
             // log message & error
             String errorCause =
                     "Message "
                             + edxlMessage.getDistributionID()
                             + " has been read from dead-letter-queue; reason was "
-                            + message.getMessageProperties().getHeader(DLQ_REASON);
+                            + dlqReason;
             String messageType =
                     EdxlUtils.getUseCaseFromMessage(edxlMessage.getFirstContentMessage());
             String recipientId = MessageUtils.getRecipientID(edxlMessage);
+
             DeadLetteredMessageException exception =
                     new DeadLetteredMessageException(
                             errorCause, edxlMessage.getDistributionID(), recipientId, messageType);
-            messageHandler.handleError(exception, message);
+            if (dlqReason.equals(DLQ_EXPIRED_REASON)) {
+
+                messageHandler.handleError(exception, message);
+            } else {
+                throw new AmqpRejectAndDontRequeueException(exception);
+            }
+
         } catch (Exception e) {
             // We don't want to log again the error if it has been thrown by handleError
             // We just log the unexpected errors

--- a/hub/dispatcher/src/main/java/com/hubsante/hub/service/Dispatcher.java
+++ b/hub/dispatcher/src/main/java/com/hubsante/hub/service/Dispatcher.java
@@ -332,27 +332,19 @@ public class Dispatcher {
                 return;
             }
             EdxlMessage edxlMessage = messageHandler.extractMessage(message);
-            String dlqReason = message.getMessageProperties().getHeader(DLQ_REASON);
             // log message & error
             String errorCause =
                     "Message "
                             + edxlMessage.getDistributionID()
                             + " has been read from dead-letter-queue; reason was "
-                            + dlqReason;
+                            + message.getMessageProperties().getHeader(DLQ_REASON);
             String messageType =
                     EdxlUtils.getUseCaseFromMessage(edxlMessage.getFirstContentMessage());
             String recipientId = MessageUtils.getRecipientID(edxlMessage);
-
             DeadLetteredMessageException exception =
                     new DeadLetteredMessageException(
                             errorCause, edxlMessage.getDistributionID(), recipientId, messageType);
-            if (dlqReason.equals(DLQ_EXPIRED_REASON)) {
-
-                messageHandler.handleError(exception, message);
-            } else {
-                throw new AmqpRejectAndDontRequeueException(exception);
-            }
-
+            messageHandler.handleError(exception, message);
         } catch (Exception e) {
             // We don't want to log again the error if it has been thrown by handleError
             // We just log the unexpected errors

--- a/hub/dispatcher/src/main/java/com/hubsante/hub/service/MessageHandler.java
+++ b/hub/dispatcher/src/main/java/com/hubsante/hub/service/MessageHandler.java
@@ -131,11 +131,16 @@ public class MessageHandler {
         logErrorMessage(error, distributionId, senderClientId, recipientId, messageType);
         // currently, we do not handle error messages on other hubex, and inhibit DLQ messages other
         // than the "expired" ones
-        if (senderClientId.startsWith(FR_HEALTH_PREFIX) && !isInhibitedErrorMessage(message)) {
+        boolean isSenderInHealthPerimeter = senderClientId.startsWith(FR_HEALTH_PREFIX);
+        if (isSenderInHealthPerimeter && !isInhibitedErrorMessage(message)) {
             sendErrorReport(error, senderClientId);
         } else {
+            String errorLog =
+                    isSenderInHealthPerimeter
+                            ? "Error message not sent as it is not a health perimeter"
+                            : "Error message not sent as it has been dead-letter-queued for an other reason than expiration";
             structuredLog.info(
-                    "Error message not sent as it is not a health perimeter",
+                    errorLog,
                     Map.of(
                             LogConstants.SENDER_ID,
                             senderClientId,

--- a/hub/dispatcher/src/main/java/com/hubsante/hub/service/MessageHandler.java
+++ b/hub/dispatcher/src/main/java/com/hubsante/hub/service/MessageHandler.java
@@ -137,8 +137,8 @@ public class MessageHandler {
         } else {
             String errorLog =
                     isSenderInHealthPerimeter
-                            ? "Error message not sent as it is not a health perimeter"
-                            : "Error message not sent as it has been dead-letter-queued for an other reason than expiration";
+                            ? "Error message not sent as it has been dead-letter-queued for an other reason than expiration"
+                            : "Error message not sent as it is not a health perimeter";
             structuredLog.info(
                     errorLog,
                     Map.of(

--- a/hub/dispatcher/src/main/java/com/hubsante/hub/service/MessageHandler.java
+++ b/hub/dispatcher/src/main/java/com/hubsante/hub/service/MessageHandler.java
@@ -15,8 +15,7 @@
  */
 package com.hubsante.hub.service;
 
-import static com.hubsante.hub.config.AmqpConfiguration.DISTRIBUTION_EXCHANGE;
-import static com.hubsante.hub.config.AmqpConfiguration.ORIGINAL_ROUTING_KEY;
+import static com.hubsante.hub.config.AmqpConfiguration.*;
 import static com.hubsante.hub.config.Constants.*;
 import static com.hubsante.hub.utils.ConfigUtils.sanitizeVhostForProm;
 import static com.hubsante.hub.utils.EdxlUtils.HUB_ID;
@@ -130,8 +129,9 @@ public class MessageHandler {
         String messageType = exception.getMessageType();
 
         logErrorMessage(error, distributionId, senderClientId, recipientId, messageType);
-        // currently, we do not handle error messages on other hubex
-        if (senderClientId.startsWith(FR_HEALTH_PREFIX)) {
+        // currently, we do not handle error messages on other hubex, and inhibit DLQ messages other
+        // than the "expired" ones
+        if (senderClientId.startsWith(FR_HEALTH_PREFIX) && !isInhibitedErrorMessage(message)) {
             sendErrorReport(error, senderClientId);
         } else {
             structuredLog.info(

--- a/hub/dispatcher/src/main/java/com/hubsante/hub/utils/MessageUtils.java
+++ b/hub/dispatcher/src/main/java/com/hubsante/hub/utils/MessageUtils.java
@@ -344,7 +344,7 @@ public class MessageUtils {
     }
 
     public static boolean isInhibitedErrorMessage(Message message) {
-        return message.getMessageProperties().getHeader(DLQ_REASON) != null
-                && !message.getMessageProperties().getHeader(DLQ_REASON).equals(DLQ_EXPIRED_REASON);
+        String dlqReasonHeader = message.getMessageProperties().getHeader(DLQ_REASON);
+        return dlqReasonHeader != null && !dlqReasonHeader.equals(DLQ_EXPIRED_REASON);
     }
 }

--- a/hub/dispatcher/src/main/java/com/hubsante/hub/utils/MessageUtils.java
+++ b/hub/dispatcher/src/main/java/com/hubsante/hub/utils/MessageUtils.java
@@ -15,7 +15,7 @@
  */
 package com.hubsante.hub.utils;
 
-import static com.hubsante.hub.config.AmqpConfiguration.ORIGINAL_ROUTING_KEY;
+import static com.hubsante.hub.config.AmqpConfiguration.*;
 import static com.hubsante.hub.config.Constants.DISTRIBUTION_ID_UNAVAILABLE;
 
 import com.hubsante.hub.config.Constants;
@@ -341,5 +341,10 @@ public class MessageUtils {
 
     public static String stringifyBody(Message message) {
         return new String(message.getBody(), StandardCharsets.UTF_8);
+    }
+
+    public static boolean isInhibitedErrorMessage(Message message) {
+        return message.getMessageProperties().getHeader(DLQ_REASON) != null
+                && !message.getMessageProperties().getHeader(DLQ_REASON).equals(DLQ_EXPIRED_REASON);
     }
 }

--- a/hub/dispatcher/src/test/java/com/hubsante/hub/service/DispatcherTest.java
+++ b/hub/dispatcher/src/test/java/com/hubsante/hub/service/DispatcherTest.java
@@ -535,7 +535,7 @@ public class DispatcherTest {
     public void handleDLQRejectedMessage() throws Exception {
         // we test that a rejected message received on the DLQ listener does not trigger a RS-ERROR
         Message originalMessage = createMessage("EDXL-DE", JSON, SAMU_A_ROUTING_KEY);
-        Message dlqMessage = applyRabbitmqDLQHeaders(originalMessage, "rejected");
+        Message dlqMessage = applyRabbitmqDLQHeaders(originalMessage, DLQ_REJECTED_REASON);
         ArgumentCaptor<Message> argCaptor = ArgumentCaptor.forClass(Message.class);
         assertThrows(
                 AmqpRejectAndDontRequeueException.class, () -> dispatcher.dispatchDLQ(dlqMessage));

--- a/hub/dispatcher/src/test/java/com/hubsante/hub/service/DispatcherTest.java
+++ b/hub/dispatcher/src/test/java/com/hubsante/hub/service/DispatcherTest.java
@@ -515,7 +515,7 @@ public class DispatcherTest {
     @Test
     @DisplayName("should send info to sender of DLQed message - expiration")
     public void handleDLQMessage() throws Exception {
-        // we test that the message has been rejected after the DLQ listener has been called
+        // we test that an expired message has been rejected after the DLQ listener has been called
         Message originalMessage = createMessage("EDXL-DE", JSON, SAMU_A_ROUTING_KEY);
         Message dlqMessage = applyRabbitmqDLQHeaders(originalMessage, "expired");
         assertThrows(
@@ -528,6 +528,21 @@ public class DispatcherTest {
                 SAMU_A_DISTRIBUTION_ID,
                 "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
                 "has been read from dead-letter-queue; reason was expired");
+    }
+
+    @Test
+    @DisplayName("should send info to sender of DLQed message - expiration")
+    public void handleDLQRejectedMessage() throws Exception {
+        // we test that a rejected message received on the DLQ listener does not trigger a RS-ERROR
+        Message originalMessage = createMessage("EDXL-DE", JSON, SAMU_A_ROUTING_KEY);
+        Message dlqMessage = applyRabbitmqDLQHeaders(originalMessage, "rejected");
+        ArgumentCaptor<Message> argCaptor = ArgumentCaptor.forClass(Message.class);
+        assertThrows(
+                AmqpRejectAndDontRequeueException.class, () -> dispatcher.dispatchDLQ(dlqMessage));
+
+        // No message has been published on sender info queue
+        Mockito.verify(rabbitTemplate, times(0))
+                .send(eq(DISTRIBUTION_EXCHANGE), eq(SAMU_A_INFO_QUEUE), argCaptor.capture());
     }
 
     @Test

--- a/hub/dispatcher/src/test/java/com/hubsante/hub/service/DispatcherTest.java
+++ b/hub/dispatcher/src/test/java/com/hubsante/hub/service/DispatcherTest.java
@@ -517,7 +517,7 @@ public class DispatcherTest {
     public void handleDLQMessage() throws Exception {
         // we test that an expired message has been rejected after the DLQ listener has been called
         Message originalMessage = createMessage("EDXL-DE", JSON, SAMU_A_ROUTING_KEY);
-        Message dlqMessage = applyRabbitmqDLQHeaders(originalMessage, "expired");
+        Message dlqMessage = applyRabbitmqDLQHeaders(originalMessage, DLQ_EXPIRED_REASON);
         assertThrows(
                 AmqpRejectAndDontRequeueException.class, () -> dispatcher.dispatchDLQ(dlqMessage));
 
@@ -531,7 +531,7 @@ public class DispatcherTest {
     }
 
     @Test
-    @DisplayName("should send info to sender of DLQed message - expiration")
+    @DisplayName("should send info to sender of DLQed message - rejection")
     public void handleDLQRejectedMessage() throws Exception {
         // we test that a rejected message received on the DLQ listener does not trigger a RS-ERROR
         Message originalMessage = createMessage("EDXL-DE", JSON, SAMU_A_ROUTING_KEY);

--- a/hub/dispatcher/src/test/java/com/hubsante/hub/service/RabbitIntegrationTest.java
+++ b/hub/dispatcher/src/test/java/com/hubsante/hub/service/RabbitIntegrationTest.java
@@ -176,12 +176,7 @@ public class RabbitIntegrationTest extends RabbitIntegrationAbstract {
                 });
         Thread.sleep(DISPATCHER_PROCESS_TIME);
         assertRecipientDidNotReceive("samuB", SAMU_B_MESSAGE_QUEUE);
-        assertErrorHasBeenReceived(
-                samuA_publisher,
-                SAMU_A_INFO_QUEUE,
-                ErrorCode.DEAD_LETTER_QUEUED,
-                "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea",
-                "rejected");
+        assertRecipientDidNotReceive("samuA", SAMU_A_INFO_QUEUE);
     }
 
     private void assertRecipientDidNotReceive(String client, String queueName) throws Exception {


### PR DESCRIPTION
## 🔎 Détails

Dans le listener de la DLQ, désormais : 
- [x] on log tous les messages reçus de la DLQ comme avant
- [x] on inhibe l'envoi de messages d'erreur pour tous les messages DLQd pour une autre raison que l'expiration
- [x] pour les cas inhibés, on lève dans le listener l'`AmqpRejectAndDontRequeueException`, car elle nécessaire pour l'acquittement technique du message (elle est levée dans handleError mais on ne passe plus par cette méthode pour les cas inhibés).  

## 🔗Ticket associé

[[ Dispatcher ] - [ DLQ ] - Envoi conditionnel d'un message d'erreur](https://app.asana.com/1/1201445755223134/project/1213900980560885/task/1213747710745821)
