### PR TITLE
feat(lrm): envoi d'un message d'erreur associé à l'acquittement refused

### DIFF
--- a/web/lrm/client/components/ReceivedMessage.vue
+++ b/web/lrm/client/components/ReceivedMessage.vue
@@ -217,7 +217,7 @@ const sendAck = (refused = false) => {
     if (getMessageType({ body: props.body }) !== 'message') return;
     if (senderID.includes(INTERNAL_HUB_USER)) return;
 
-    let errorDistributionId = null;
+    let errorDistributionID = null;
 
     if (refused) {
       const errorMsg = buildError({
@@ -226,14 +226,14 @@ const sendAck = (refused = false) => {
         sourceMessage: props.body,
       });
       sendMessage(errorMsg, props.vhost);
-      errorDistributionId = errorMsg.distributionID;
+      errorDistributionID = errorMsg.distributionID;
     }
 
     const msg = buildAck({
       distributionID,
       senderID,
       refused,
-      errorDistributionId,
+      errorDistributionID,
     });
     sendMessage(msg, props.vhost);
     isAcked.value = true;
@@ -267,6 +267,7 @@ export default {
   },
 };
 </script>
+
 <style lang="scss">
 // Ref.: https://github.com/chenfengjw163/vue-json-viewer/tree/master#theming
 // values are default one from jv-light template

--- a/web/lrm/client/components/ReceivedMessage.vue
+++ b/web/lrm/client/components/ReceivedMessage.vue
@@ -214,8 +214,13 @@ const sendAck = (refused = false) => {
     const distributionID = props.body.distributionID;
     const senderID = props.body.senderID;
 
-    if (getMessageType({ body: props.body }) !== 'message') return;
-    if (senderID.includes(INTERNAL_HUB_USER)) return;
+    if (getMessageType({ body: props.body }) !== 'message') {
+      return;
+    }
+    if (senderID.includes(INTERNAL_HUB_USER)) {
+      consola.warn(`Ack not sent: ${INTERNAL_HUB_USER} is not a valid client`);
+      return;
+    }
 
     let errorDistributionID = null;
 

--- a/web/lrm/client/components/ReceivedMessage.vue
+++ b/web/lrm/client/components/ReceivedMessage.vue
@@ -132,6 +132,7 @@ import { useMainStore } from '~/store';
 import { useAuthStore } from '@/store/auth';
 import {
   buildAck,
+  buildError,
   sendMessage,
   INTERNAL_HUB_USER,
   getMessageType,
@@ -214,12 +215,26 @@ const sendAck = (refused = false) => {
     const senderID = props.body.senderID;
 
     if (getMessageType({ body: props.body }) !== 'message') return;
+    if (senderID.includes(INTERNAL_HUB_USER)) return;
 
-    if (senderID.includes(INTERNAL_HUB_USER)) {
-      consola.warn(`Ack not sent: ${INTERNAL_HUB_USER} is not a valid client`);
-      return;
+    let errorDistributionId = null;
+
+    if (refused) {
+      const errorMsg = buildError({
+        distributionID,
+        senderID,
+        sourceMessage: props.body,
+      });
+      sendMessage(errorMsg, props.vhost);
+      errorDistributionId = errorMsg.distributionID;
     }
-    const msg = buildAck({ distributionID, senderID, refused });
+
+    const msg = buildAck({
+      distributionID,
+      senderID,
+      refused,
+      errorDistributionId,
+    });
     sendMessage(msg, props.vhost);
     isAcked.value = true;
   } catch (error) {

--- a/web/lrm/client/composables/messageUtils.js
+++ b/web/lrm/client/composables/messageUtils.js
@@ -147,27 +147,25 @@ export function buildAck({
 }
 
 export function buildError({ distributionID, senderID, sourceMessage }) {
-  const msg = buildMessage(
+  return buildMessage(
     {
       error: {
         errorCode: { statusCode: 501, statusString: 'UNROUTABLE_MESSAGE' },
         errorCause: 'This message was rejected by the recipient.',
-        referencedDistributionID: distributionID,
         sourceMessage,
+        referencedDistributionID: distributionID,
       },
     },
-    { distributionKind: 'Error', recipientId: senderID }
+    { distributionKind: 'Error', recipientId: senderID, includeRCDE: false }
   );
-  msg.content[0].jsonContent.embeddedJsonContent.message = {
-    error: msg.content[0].jsonContent.embeddedJsonContent.message.error,
-  };
-  return msg;
 }
+
 export function buildMessage(
   innerMessage,
-  { distributionKind, recipientId } = {
+  { distributionKind, recipientId, includeRCDE = true } = {
     distributionKind: 'Report',
     recipientId: null,
+    includeRCDE: true,
   }
 ) {
   // InnerMessage should only have one key, as we do not support multiple use cases in the same message.
@@ -184,12 +182,8 @@ export function buildMessage(
   } else {
     message.descriptor.keyword[0].value = useCase;
   }
+
   const formattedInnerMessage = formatIdsInMessage(innerMessage);
-  message.content[0].jsonContent.embeddedJsonContent.message = {
-    ...message.content[0].jsonContent.embeddedJsonContent.message,
-    ...formattedInnerMessage,
-  };
-  const name = clientInfos().name;
   const targetId = recipientId ?? authStore.user.targetId;
   const sentAt = moment().format();
   message.distributionID = `${authStore.user.clientId}_${uuidv4()}`;
@@ -197,21 +191,32 @@ export function buildMessage(
   message.senderID = authStore.user.clientId;
   message.dateTimeSent = sentAt;
   message.descriptor.explicitAddress.explicitAddressValue = targetId;
-  message.content[0].jsonContent.embeddedJsonContent.message.messageId =
-    message.distributionID;
-  message.content[0].jsonContent.embeddedJsonContent.message.kind =
-    message.distributionKind;
-  message.content[0].jsonContent.embeddedJsonContent.message.sender = {
-    name,
-    URI: `hubex:${authStore.user.clientId}`,
-  };
-  message.content[0].jsonContent.embeddedJsonContent.message.sentAt = sentAt;
-  message.content[0].jsonContent.embeddedJsonContent.message.recipient = [
-    {
-      name: clientInfos(targetId).name,
-      URI: `hubex:${targetId}`,
-    },
-  ];
+
+  if (includeRCDE) {
+    const name = clientInfos().name;
+    message.content[0].jsonContent.embeddedJsonContent.message = {
+      ...message.content[0].jsonContent.embeddedJsonContent.message,
+      ...formattedInnerMessage,
+      messageId: message.distributionID,
+      kind: message.distributionKind,
+      sender: {
+        name,
+        URI: `hubex:${authStore.user.clientId}`,
+      },
+      sentAt,
+      recipient: [
+        {
+          name: clientInfos(targetId).name,
+          URI: `hubex:${targetId}`,
+        },
+      ],
+    };
+  } else {
+    message.content[0].jsonContent.embeddedJsonContent.message = {
+      ...formattedInnerMessage,
+    };
+  }
+
   return trimEmptyValues(message);
 }
 

--- a/web/lrm/client/composables/messageUtils.js
+++ b/web/lrm/client/composables/messageUtils.js
@@ -138,7 +138,7 @@ export function buildAck({
         distributionID,
         ...(refused && { refused }),
         ...(errorDistributionID && {
-          errorDistributionID: errorDistributionID,
+          errorDistributionID,
         }),
       },
     },
@@ -153,7 +153,7 @@ export function buildError({ distributionID, senderID, sourceMessage }) {
         errorCode: { statusCode: 700, statusString: 'INTERNAL_CLIENT_ERROR' },
         errorCause: 'This message was rejected by the recipient.',
         referencedDistributionID: distributionID,
-        sourceMessage: sourceMessage,
+        sourceMessage,
       },
     },
     { distributionKind: 'Error', recipientId: senderID }

--- a/web/lrm/client/composables/messageUtils.js
+++ b/web/lrm/client/composables/messageUtils.js
@@ -130,15 +130,15 @@ export function buildAck({
   distributionID,
   senderID,
   refused = false,
-  errorDistributionId = null,
+  errorDistributionID = null,
 }) {
   return buildMessage(
     {
       reference: {
         distributionID,
         ...(refused && { refused }),
-        ...(errorDistributionId && {
-          errorDistributionID: errorDistributionId,
+        ...(errorDistributionID && {
+          errorDistributionID: errorDistributionID,
         }),
       },
     },

--- a/web/lrm/client/composables/messageUtils.js
+++ b/web/lrm/client/composables/messageUtils.js
@@ -2,7 +2,7 @@ import moment from 'moment/moment';
 import { v4 as uuidv4 } from 'uuid';
 import { consola } from 'consola';
 import { clientInfos } from './userUtils';
-import { EDXL_ENVELOPE, DIRECTIONS } from '@/constants';
+import { EDXL_ENVELOPE, DIRECTIONS, RC_DE } from '@/constants';
 import { useMainStore } from '~/store';
 import { useAuthStore } from '~/store/auth';
 
@@ -196,6 +196,7 @@ export function buildMessage(
     const name = clientInfos().name;
     message.content[0].jsonContent.embeddedJsonContent.message = {
       ...message.content[0].jsonContent.embeddedJsonContent.message,
+      ...RC_DE,
       ...formattedInnerMessage,
       messageId: message.distributionID,
       kind: message.distributionKind,
@@ -215,12 +216,6 @@ export function buildMessage(
     message.content[0].jsonContent.embeddedJsonContent.message = {
       ...message.content[0].jsonContent.embeddedJsonContent.message,
       ...formattedInnerMessage,
-      messageId: undefined,
-      kind: undefined,
-      sender: undefined,
-      sentAt: undefined,
-      recipient: undefined,
-      status: undefined,
     };
   }
 

--- a/web/lrm/client/composables/messageUtils.js
+++ b/web/lrm/client/composables/messageUtils.js
@@ -150,7 +150,7 @@ export function buildError({ distributionID, senderID, sourceMessage }) {
   const msg = buildMessage(
     {
       error: {
-        errorCode: { statusCode: 700, statusString: 'INTERNAL_CLIENT_ERROR' },
+        errorCode: { statusCode: 501, statusString: 'UNROUTABLE_MESSAGE' },
         errorCause: 'This message was rejected by the recipient.',
         referencedDistributionID: distributionID,
         sourceMessage,

--- a/web/lrm/client/composables/messageUtils.js
+++ b/web/lrm/client/composables/messageUtils.js
@@ -126,13 +126,43 @@ export function setCaseId(message, caseId, localCaseId) {
   }
 }
 
-export function buildAck({ distributionID, senderID, refused = false }) {
+export function buildAck({
+  distributionID,
+  senderID,
+  refused = false,
+  errorDistributionId = null,
+}) {
   return buildMessage(
-    { reference: { distributionID, ...(refused && { refused }) } },
+    {
+      reference: {
+        distributionID,
+        ...(refused && { refused }),
+        ...(errorDistributionId && {
+          errorDistributionID: errorDistributionId,
+        }),
+      },
+    },
     { distributionKind: 'Ack', recipientId: senderID }
   );
 }
 
+export function buildError({ distributionID, senderID, sourceMessage }) {
+  const msg = buildMessage(
+    {
+      error: {
+        errorCode: { statusCode: 700, statusString: 'INTERNAL_CLIENT_ERROR' },
+        errorCause: 'This message was rejected by the recipient.',
+        referencedDistributionID: distributionID,
+        sourceMessage: sourceMessage,
+      },
+    },
+    { distributionKind: 'Error', recipientId: senderID }
+  );
+  msg.content[0].jsonContent.embeddedJsonContent.message = {
+    error: msg.content[0].jsonContent.embeddedJsonContent.message.error,
+  };
+  return msg;
+}
 export function buildMessage(
   innerMessage,
   { distributionKind, recipientId } = {

--- a/web/lrm/client/composables/messageUtils.js
+++ b/web/lrm/client/composables/messageUtils.js
@@ -213,7 +213,14 @@ export function buildMessage(
     };
   } else {
     message.content[0].jsonContent.embeddedJsonContent.message = {
+      ...message.content[0].jsonContent.embeddedJsonContent.message,
       ...formattedInnerMessage,
+      messageId: undefined,
+      kind: undefined,
+      sender: undefined,
+      sentAt: undefined,
+      recipient: undefined,
+      status: undefined,
     };
   }
 

--- a/web/lrm/client/constants.js
+++ b/web/lrm/client/constants.js
@@ -27,26 +27,29 @@ export const EDXL_ENVELOPE = {
     {
       jsonContent: {
         embeddedJsonContent: {
-          message: {
-            messageId: '{{ 2608323d-507d-4cbf-bf74-52007f8124ea }}',
-            sender: {
-              name: '{{ samuA }}',
-              URI: '{{ hubsante:fr.health.test.samuA }}',
-            },
-            sentAt: '{{ 2022-09-27T08:23:34+02:00 }}',
-            status: 'Actual',
-            kind: '{{ Report }}',
-            recipient: [
-              {
-                name: '{{ samuB }}',
-                URI: '{{ hubsante:fr.health.test.samuB }}',
-              },
-            ],
-          },
+          message: {},
         },
       },
     },
   ],
 };
+
+export const RC_DE = {
+  messageId: '{{ 2608323d-507d-4cbf-bf74-52007f8124ea }}',
+  sender: {
+    name: '{{ samuA }}',
+    URI: '{{ hubsante:fr.health.test.samuA }}',
+  },
+  sentAt: '{{ 2022-09-27T08:23:34+02:00 }}',
+  status: 'Actual',
+  kind: '{{ Report }}',
+  recipient: [
+    {
+      name: '{{ samuB }}',
+      URI: '{{ hubsante:fr.health.test.samuB }}',
+    },
+  ],
+};
+
 export const REPOSITORY_URL =
   'https://raw.githubusercontent.com/ansforge/SAMU-Hub-Modeles/';


### PR DESCRIPTION
## 🔎 Détails

1.Envoi d'un message d'erreur avec les valeurs suivantes : 

- ErrorCode : 501- UNROUTABLE_MESSAGE

- ErrorCause : This message was rejected by the recipient.

- SourceMessage : message initial

- ReferencedDistributionId : id du message initial 

2. Générer un acquittement avec  : 

- errorDistributionID : id du message d'erreur associé 


## 📸 Captures d'écran
<img width="362" height="307" alt="image" src="https://github.com/user-attachments/assets/19ef02fb-0679-40ce-85f4-1fcccd27b6f8" />


<img width="367" height="219" alt="image" src="https://github.com/user-attachments/assets/cd38fbce-8d85-4f9b-bc46-b684bb7ee27b" />
## 🔗Ticket associé

[Asana](https://app.asana.com/1/1201445755223134/project/1213900980560885/task/1214100215318324?focus=true)