### PR TITLE
feat(healthcheck): downgrade gunicorn workers

### DIFF
--- a/tools/healthcheck/Dockerfile
+++ b/tools/healthcheck/Dockerfile
@@ -42,4 +42,4 @@ COPY --chown=healthcheck:healthcheck . .
 EXPOSE 8080
 
 # Use Gunicorn to serve the Flask app
-CMD ["uv", "run", "gunicorn", "-w", "4", "-b", "0.0.0.0:8080", "healthcheck:app", "--timeout", "300", "--log-level=debug"]
+CMD ["uv", "run", "gunicorn", "-w", "2", "-b", "0.0.0.0:8080", "healthcheck:app", "--timeout", "300", "--log-level=debug"]


### PR DESCRIPTION
## 🔎 Détails

Actuellement on a 4 workers qui tournent via gunicorn pour le healthcheck. C'est overkill et dans un cluster kube on préfère gérer le scaling via de nouveaux pods plutôt qu'en interne dans le container.

## 🔗Ticket associé

[Asana](https://app.asana.com/1/1201445755223134/project/1213900980560885/task/1214192650614081?focus=true)

## Validation

- [x] Lancer le build de l'image `cd tools/healthcheck && docker build -t healthcheck .`
- [x] Lancer le run : `docker run -p 8085:8080 healthcheck`



