### PR TITLE
feat(lrm): ajout du toggle pour l’arborescence JSON

### DIFF
--- a/web/lrm/client/components/ReceivedMessage.vue
+++ b/web/lrm/client/components/ReceivedMessage.vue
@@ -105,17 +105,36 @@
                 : 'mdi-magnify-minus-outline'
             }}</v-icon>
           </v-btn>
+          <v-btn
+            icon
+            variant="text"
+            size="x-small"
+            color="primary"
+            @click="expandAll"
+          >
+            <v-icon size="24">mdi-unfold-more-vertical</v-icon>
+          </v-btn>
+          <v-btn
+            icon
+            variant="text"
+            size="x-small"
+            color="primary"
+            @click="collapseAll"
+          >
+            <v-icon size="24">mdi-unfold-less-vertical</v-icon>
+          </v-btn>
         </span>
       </v-row>
 
       <json-viewer
         v-if="!dense"
+        :key="jsonViewerKey"
         :value="
           showFullMessage
             ? body
             : body.content[0].jsonContent.embeddedJsonContent.message
         "
-        :expand-depth="jsonDepth"
+        :expand-depth="jsonDepthLocal"
         :copyable="{ copyText: 'Copier', copiedText: 'Copié !', timeout: 1000 }"
         expanded
         theme="json-theme"
@@ -245,6 +264,19 @@ const sendAck = (refused = false) => {
   } catch (error) {
     consola.error("Erreur lors de l'envoi de l'acquittement", error);
   }
+};
+
+const jsonViewerKey = ref(0);
+const jsonDepthLocal = ref(props.jsonDepth);
+
+const expandAll = () => {
+  jsonDepthLocal.value = 99;
+  jsonViewerKey.value++;
+};
+
+const collapseAll = () => {
+  jsonDepthLocal.value = 1;
+  jsonViewerKey.value++;
 };
 
 //on mounted, send ack if autoAckConfig is enabled


### PR DESCRIPTION
## 🔎 Détails

Ajout de la possibilité d’ouvrir/fermer toute l’arborescence JSON dans le volet Message.

Ajouter deux icones (tout ouvrir et tout fermer) pour pouvoir ouvrir / fermer toute l'arborescence JSON du message.


## 📸 Captures d'écran

<img width="357" height="275" alt="image" src="https://github.com/user-attachments/assets/082bb2eb-0561-48c6-8f79-c56539496925" />

<img width="353" height="135" alt="image" src="https://github.com/user-attachments/assets/00d4665a-09d0-4776-bc82-acc0d7af8503" />

## 🔗Ticket associé

[Asana](https://app.asana.com/1/1201445755223134/project/1214077323418181/task/1214196701759728?focus=true)