### PR TITLE
[Dispatcher] Inhibition de certains types de message par client

### DIFF
--- a/hub/dispatcher/build.gradle
+++ b/hub/dispatcher/build.gradle
@@ -75,6 +75,7 @@ dependencies {
     implementation "com.univocity:univocity-parsers:${libs.versions.univocityParsers.get()}"
     implementation "org.codehaus.groovy:groovy-json:${libs.versions.groovyJson.get()}"
     implementation "org.json:json:${libs.versions.orgJson.get()}"
+    implementation "org.apache.commons:commons-csv:${libs.versions.apacheCommonsCsv.get()}"
 
     // ===== Lombok =====
     compileOnly 'org.projectlombok:lombok'

--- a/hub/dispatcher/gradle/libs.versions.toml
+++ b/hub/dispatcher/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ groovyJson = "3.0.9"
 orgJson = "20231013"
 googleJavaFormat = "1.29.0"
 embedMongo = "4.24.0"
+apacheCommonsCsv = "1.14.1"
 
 [plugins]
 spring-boot = { id = "org.springframework.boot", version.ref = "springBoot" }

--- a/hub/dispatcher/src/main/java/com/hubsante/hub/config/HubConfiguration.java
+++ b/hub/dispatcher/src/main/java/com/hubsante/hub/config/HubConfiguration.java
@@ -38,7 +38,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 @Configuration
 public class HubConfiguration {
 
-    private static final int ROW_LENGTH = 9;
+    private static final int ROW_LENGTH = 10;
     private static final String DATA_DIVIDER = ",";
     private static final String COLUMN_DIVIDER = ";";
 

--- a/hub/dispatcher/src/main/java/com/hubsante/hub/config/HubConfiguration.java
+++ b/hub/dispatcher/src/main/java/com/hubsante/hub/config/HubConfiguration.java
@@ -26,9 +26,13 @@ import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.annotation.PostConstruct;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.*;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -38,9 +42,11 @@ import org.springframework.web.reactive.function.client.WebClient;
 @Configuration
 public class HubConfiguration {
 
-    private static final int ROW_LENGTH = 10;
+    private static final int ROW_LENGTH = 11;
     private static final String DATA_DIVIDER = ",";
     private static final String COLUMN_DIVIDER = ";";
+    private static final String CLIENT_ID_HEADER = "client_id";
+    private static final String INHIBITED_USE_CASES_HEADER = "inhibited_use_cases";
 
     @Value("${client.preferences.file}")
     private File configFile;
@@ -60,6 +66,7 @@ public class HubConfiguration {
     private HashMap<String, Boolean> directCisuPreferences = new HashMap<>();
     private HashMap<String, String> clientsEditorMap = new HashMap<>();
     private Map<String, Map<String, String>> clientsPerimeterAndVersions = new HashMap<>();
+    private Map<String, List<String>> clientsInhibitedMessages = new HashMap<>();
     private List<String> supportedMessages;
 
     @PostConstruct
@@ -100,6 +107,7 @@ public class HubConfiguration {
             CsvParser parser = new CsvParser(parserSettings);
             parser.parse(new BufferedReader(new FileReader(configFile, StandardCharsets.UTF_8)));
             clientsPerimeterAndVersions = loadClientsPerimetersAndVersions();
+            clientsInhibitedMessages = loadClientsInhibitedMessages();
             supportedMessages = loadSupportedMessages(vhost);
         } catch (Exception e) {
             throw new Exception("Could not read config file " + configFile.getAbsolutePath(), e);
@@ -187,6 +195,44 @@ public class HubConfiguration {
         return supportedMessages;
     }
 
+    private Map<String, List<String>> loadClientsInhibitedMessages() throws IOException {
+        Map<String, List<String>> result = new HashMap<>();
+
+        try (Reader reader = Files.newBufferedReader(configFile.toPath());
+                CSVParser parser =
+                        CSVFormat.DEFAULT
+                                .builder()
+                                .setDelimiter(';')
+                                .setHeader()
+                                .setSkipHeaderRecord(true)
+                                .setTrim(true)
+                                .build()
+                                .parse(reader)) {
+            boolean hasUseCasesColumn =
+                    parser.getHeaderMap().containsKey(INHIBITED_USE_CASES_HEADER);
+
+            for (CSVRecord record : parser) {
+
+                String clientId = record.get(CLIENT_ID_HEADER);
+                List<String> useCases;
+
+                if (hasUseCasesColumn) {
+                    useCases =
+                            Arrays.stream(record.get(INHIBITED_USE_CASES_HEADER).split(","))
+                                    .map(String::trim)
+                                    .filter(s -> !s.isEmpty())
+                                    .toList();
+                } else {
+                    useCases = List.of();
+                }
+
+                result.put(clientId, useCases);
+            }
+        }
+
+        return Collections.unmodifiableMap(result);
+    }
+
     public List<String> getSupportedMessages() {
         return supportedMessages;
     }
@@ -201,6 +247,10 @@ public class HubConfiguration {
 
     public HashMap<String, String> getClientsEditorMap() {
         return clientsEditorMap;
+    }
+
+    public Map<String, List<String>> getClientsInhibitedMessages() {
+        return clientsInhibitedMessages;
     }
 
     public long getDefaultTTL() {

--- a/hub/dispatcher/src/main/java/com/hubsante/hub/service/Dispatcher.java
+++ b/hub/dispatcher/src/main/java/com/hubsante/hub/service/Dispatcher.java
@@ -201,6 +201,8 @@ public class Dispatcher {
             EdxlMessage edxlMessage = messageHandler.extractMessage(message);
             // check message type is allowed on the current vhost
             checkMessageClassNameSupported(edxlMessage, hubConfig);
+            // check message is allowed for its recipient
+            messageHandler.inhibitMessageIfNeeded(edxlMessage);
             // reject the message if no health actor is involved (as sender or recipient)
             checkHealthActorIsInvolved(edxlMessage);
             // ToDo: see how hubConfig should be made available to the Dispatcher (and remove getter

--- a/hub/dispatcher/src/main/java/com/hubsante/hub/service/MessageHandler.java
+++ b/hub/dispatcher/src/main/java/com/hubsante/hub/service/MessageHandler.java
@@ -33,6 +33,7 @@ import com.hubsante.hub.config.StructuredLogger;
 import com.hubsante.hub.exception.*;
 import com.hubsante.hub.utils.ConversionRulesCommand;
 import com.hubsante.hub.utils.ConversionUtils;
+import com.hubsante.hub.utils.EdxlUtils;
 import com.hubsante.model.EdxlHandler;
 import com.hubsante.model.Validator;
 import com.hubsante.model.builders.ErrorWrapperBuilder;
@@ -596,6 +597,14 @@ public class MessageHandler {
                         distributionId));
 
         return fwdMessage;
+    }
+
+    protected void inhibitMessageIfNeeded(EdxlMessage edxlMessage) {
+        checkMessageNotInhibited(
+                getRecipientID(edxlMessage),
+                EdxlUtils.getUseCaseFromMessage(edxlMessage.getFirstContentMessage()),
+                hubConfig.getClientsInhibitedMessages(),
+                edxlMessage.getDistributionID());
     }
 
     private void logMessage(Message message, EdxlMessage edxlMessage, String receivedEdxl) {

--- a/hub/dispatcher/src/main/java/com/hubsante/hub/utils/MessageUtils.java
+++ b/hub/dispatcher/src/main/java/com/hubsante/hub/utils/MessageUtils.java
@@ -155,6 +155,26 @@ public class MessageUtils {
         }
     }
 
+    public static void checkMessageNotInhibited(
+            String recipientId,
+            String useCase,
+            Map<String, List<String>> inhibitedMessagesByClient,
+            String distributionId) {
+
+        List<String> blockedUseCases =
+                inhibitedMessagesByClient.getOrDefault(recipientId, List.of());
+
+        boolean isInhibited = blockedUseCases.contains(useCase);
+
+        if (isInhibited) {
+            String errorMessage =
+                    String.format(
+                            "Use case %s is not supported for client %s", useCase, recipientId);
+            throw new UnroutableMessageException(
+                    errorMessage, distributionId, recipientId, useCase);
+        }
+    }
+
     public static String getInfoQueueNameFromClientId(String clientId) {
         return clientId + ".info";
     }

--- a/hub/dispatcher/src/test/java/com/hubsante/hub/utils/MessageUtilsTest.java
+++ b/hub/dispatcher/src/test/java/com/hubsante/hub/utils/MessageUtilsTest.java
@@ -16,8 +16,7 @@
 package com.hubsante.hub.utils;
 
 import static com.hubsante.hub.utils.MessageUtils.checkMessageNotInhibited;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.hubsante.hub.exception.UnroutableMessageException;
 import java.util.List;
@@ -41,7 +40,7 @@ public class MessageUtilsTest {
     @Test
     @DisplayName("should throw if message is inhibited for restricted client")
     public void shouldThrowIfMessageIsInhibited() {
-        assertThrows(
+        UnroutableMessageException thrown = assertThrows(
                 UnroutableMessageException.class,
                 () ->
                         checkMessageNotInhibited(
@@ -49,6 +48,10 @@ public class MessageUtilsTest {
                                 INHIBITED_MESSAGE,
                                 inhibitedMessagesByClient,
                                 DISTRIBUTION_ID));
+
+        assertEquals(
+                "Use case " + INHIBITED_MESSAGE + " is not supported for client " + LIMITED_CLIENT,
+                thrown.getMessage());
     }
 
     @Test

--- a/hub/dispatcher/src/test/java/com/hubsante/hub/utils/MessageUtilsTest.java
+++ b/hub/dispatcher/src/test/java/com/hubsante/hub/utils/MessageUtilsTest.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright © 2023-2026 Agence du Numerique en Sante (ANS)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hubsante.hub.utils;
+
+import static com.hubsante.hub.utils.MessageUtils.checkMessageNotInhibited;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.hubsante.hub.exception.UnroutableMessageException;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class MessageUtilsTest {
+
+    private final String UNRESTRICTED_CLIENT = "fr.health.unrestricted_client";
+    private final String LIMITED_CLIENT = "fr.health.limited_client";
+    private final String INHIBITED_MESSAGE = "ResourcesInfoCisuWrapper";
+    private final String UNRESTRICTED_MESSAGE = "CreateCaseWrapper";
+    private final String DISTRIBUTION_ID = "some_distribution_id";
+
+    Map<String, List<String>> inhibitedMessagesByClient =
+            Map.of(
+                    UNRESTRICTED_CLIENT, List.of(),
+                    LIMITED_CLIENT, List.of(INHIBITED_MESSAGE));
+
+    @Test
+    @DisplayName("should throw if message is inhibited for restricted client")
+    public void shouldThrowIfMessageIsInhibited() {
+        assertThrows(
+                UnroutableMessageException.class,
+                () ->
+                        checkMessageNotInhibited(
+                                LIMITED_CLIENT,
+                                INHIBITED_MESSAGE,
+                                inhibitedMessagesByClient,
+                                DISTRIBUTION_ID));
+    }
+
+    @Test
+    @DisplayName("should not throw if message is not inhibited for restricted client")
+    public void shouldNotThrowIfMessageIsNotInhibited() {
+        assertDoesNotThrow(
+                () ->
+                        checkMessageNotInhibited(
+                                LIMITED_CLIENT,
+                                UNRESTRICTED_MESSAGE,
+                                inhibitedMessagesByClient,
+                                DISTRIBUTION_ID));
+    }
+
+    @Test
+    @DisplayName("should not throw id client has no restrictions")
+    public void shouldNotThrowIfIdClientHasNoRestrictions() {
+        assertDoesNotThrow(
+                () ->
+                        checkMessageNotInhibited(
+                                UNRESTRICTED_CLIENT,
+                                INHIBITED_MESSAGE,
+                                inhibitedMessagesByClient,
+                                DISTRIBUTION_ID));
+    }
+}

--- a/hub/dispatcher/src/test/java/com/hubsante/hub/utils/MessageUtilsTest.java
+++ b/hub/dispatcher/src/test/java/com/hubsante/hub/utils/MessageUtilsTest.java
@@ -40,14 +40,15 @@ public class MessageUtilsTest {
     @Test
     @DisplayName("should throw if message is inhibited for restricted client")
     public void shouldThrowIfMessageIsInhibited() {
-        UnroutableMessageException thrown = assertThrows(
-                UnroutableMessageException.class,
-                () ->
-                        checkMessageNotInhibited(
-                                LIMITED_CLIENT,
-                                INHIBITED_MESSAGE,
-                                inhibitedMessagesByClient,
-                                DISTRIBUTION_ID));
+        UnroutableMessageException thrown =
+                assertThrows(
+                        UnroutableMessageException.class,
+                        () ->
+                                checkMessageNotInhibited(
+                                        LIMITED_CLIENT,
+                                        INHIBITED_MESSAGE,
+                                        inhibitedMessagesByClient,
+                                        DISTRIBUTION_ID));
 
         assertEquals(
                 "Use case " + INHIBITED_MESSAGE + " is not supported for client " + LIMITED_CLIENT,


### PR DESCRIPTION
## 🔎 Détails

Le fichier de préférences client est enrichi d'une colonne `inhibited_use_cases` permettant de lister, par client, des types de messages non supportés.

Ces types de messages, comme pour le cas existant des `supported_messages`, sont définis par le nom de la classe Java, donc au niveau du wrapper.

La colonne peut-être vide ou contenir une ou plusieurs valeurs.

J'ai créé une méthode intermédiaire, dans la classe MessageHandler, comme compromis entre deux objectifs : 
- garder un appel simple dans la méthode `Dispatcher.dispatch()`, avec le moins de paramètres possibles
- avoir une méthode vraiment purement statique et testable unitairement.

La méthode `MessageHandler.inhibitMessageIfNeeded` ne sert donc qu'à extraire les paramètres requis.


## 🔗Ticket associé

[Blocage RC-RI dans le Dispatcher](https://app.asana.com/1/1201445755223134/project/1213900980560885/task/1214492956598491)
