### PR TITLE
feat(landing) : Corrections mineures du texte de la page parcours de raccordement

### DIFF
--- a/web/landing/pages/parcours.html
+++ b/web/landing/pages/parcours.html
@@ -585,11 +585,11 @@
                                                     pouvez utiliser la commande suivante :
                                                     <span
                                                         style="display: inline-block; text-align: center; width: 100%; margin-top: 20px; margin-bottom: 20px;">
-                                                    openssl pkcs12 -in <span
-                                                        style="color: #1D71B8;"><i>cert.p12</i></span>
-                                                    -clcerts
-                                                    -nokeys -out <span style="color: #1D71B8;">
-                                                        <i>publicCert.crt</i></span></span>
+                                                        openssl pkcs12 -in <span
+                                                            style="color: #1D71B8;"><i>cert.p12</i></span>
+                                                        -clcerts
+                                                        -nokeys -out <span style="color: #1D71B8;">
+                                                            <i>publicCert.crt</i></span></span>
                                                     dans laquelle vous remplacerez <span
                                                         style="color: #1D71B8;"><i>cert.p12</i></span> par
                                                     le <u>nom du fichier p12</u>

--- a/web/landing/pages/parcours.html
+++ b/web/landing/pages/parcours.html
@@ -585,11 +585,11 @@
                                                     pouvez utiliser la commande suivante :
                                                     <span
                                                         style="display: inline-block; text-align: center; width: 100%; margin-top: 20px; margin-bottom: 20px;">
-                                                        openssl pkcs12 -in <span
-                                                            style="color: #1D71B8;"><i>cert.p12</i></span>
-                                                        -clcerts
-                                                        -nokeys -out <span style="color: #1D71B8;">
-                                                            <i>publicCert.crt</i></span></span>
+                                                    openssl pkcs12 -in <span
+                                                        style="color: #1D71B8;"><i>cert.p12</i></span>
+                                                    -clcerts
+                                                    -nokeys -out <span style="color: #1D71B8;">
+                                                        <i>publicCert.crt</i></span></span>
                                                     dans laquelle vous remplacerez <span
                                                         style="color: #1D71B8;"><i>cert.p12</i></span> par
                                                     le <u>nom du fichier p12</u>
@@ -1005,7 +1005,7 @@
                                     <p>
                                         Pour les SAMU et entités de Santé souhaitant raccorder leur logiciel en
                                         production
-                                        sur les environnements de <strong>pre-production</strong> et
+                                        sur les environnements de <strong>pré-production</strong> et
                                         <strong>production</strong>
                                         du Hub Santé, des certificats <strong>IGC Santé PROD</strong> sont
                                         nécessaires.
@@ -1096,7 +1096,8 @@
                                         <div class="wysiwyg mt-4">
 
                                             Une fois les droits d'administrateur technique obtenus,
-                                            il faut utiliser la plateforme IGC pour générer des certificats SSL_SERV.
+                                            il faut utiliser la plateforme IGC pour générer deux certificats SSL_SERV
+                                            (un pour la pré-production et un pour la production).
                                             Le FQDN (domaine) utilisé est à votre main mais doit permettre d'identifier
                                             l'entité
                                             concernée.


### PR DESCRIPTION
## 🔎 Détails

- Accent manquant sur pré-production (capture 1)
- Précision sur le nombre de certificats à générer (capture 2)

## 📸 Captures d'écran

| Avant | Après |
| ----- | ----- |
| <img width="2410" height="130" alt="image" src="https://github.com/user-attachments/assets/5c5fb824-fdbe-4e20-b187-62fd3f849b15" /> | <img width="2414" height="160" alt="image" src="https://github.com/user-attachments/assets/f88f4bab-8ed6-46a8-b392-83b6d58a68fd" /> |
| <img width="2028" height="176" alt="image" src="https://github.com/user-attachments/assets/6535b705-d6d1-4e5a-9055-d22f571b3e40" /> | <img width="2034" height="180" alt="image" src="https://github.com/user-attachments/assets/932f7373-8df7-490e-ab32-9aafdb4bc3d7" />|  

