### PR TITLE
feat(landing) : Ajout de la carte des SAMU en PROD et du statut des éditeurs dans la page "Travaux en cours"

### DIFF
--- a/web/landing/pages/travaux.html
+++ b/web/landing/pages/travaux.html
@@ -254,7 +254,7 @@
                 <div class="container paragraph-title-text text-center text-default">
                     <h2>Découvrez le catalogue des liens disponibles via le Hub Santé </h2>
                     <div class="wysiwyg text-center mt-2 mb-2">
-                       Le Hub Santé offre la possibilité d'échanger des données dans les liens suivants :
+                        Le Hub Santé offre la possibilité d'échanger des données dans les liens suivants :
                     </div>
                 </div>
                 <div class="container" style="display: flex; justify-content: space-around; flex-wrap: wrap;">
@@ -1492,40 +1492,39 @@
                             <th class="pl-1" scope="row">
                                 <p class="m-teaser__type rounded-lg text-uppercase bg-primary text-white">15-15</p>
                             </th>
-                            <td><span class="active" style="padding: 2px 8px; border-radius: 3px;"> <svg
-                                        class="svg-icon svg-valid" style="color:#368E6E;" aria-hidden="true"
-                                        focusable="false">
+                            <td><span class="active"> <svg class="svg-icon svg-valid" style="color:#368E6E;"
+                                        aria-hidden="true" focusable="false">
                                         <use xlink:href="/svg-icons/icon-sprite.svg#valid"></use>
                                     </svg>
                                     En production</span></td>
 
-                            <td>                                <span class="test" style="padding: 2px 8px; margin-right: 8px; border-radius: 3px;">
+                            <td> <span class="test">
                                     <svg class="svg-icon svg-play" aria-hidden="true" focusable="false">
                                         <use xlink:href="/svg-icons/icon-sprite.svg#play"></use>
                                     </svg> Tests ANS validés</span>
                             </td>
-                            <td> <span class="dev" style="padding: 2px 8px; margin-right: 8px; border-radius: 3px;">
+                            <td> <span class="dev">
                                     <svg class="svg-icon svg-time" aria-hidden="true" focusable="false">
                                         <use xlink:href="/svg-icons/icon-sprite.svg#time"></use>
                                     </svg>
                                     <span>En développement</span>
                                 </span>
                             </td>
-                            <td> <span class="dev" style="padding: 2px 8px; margin-right: 8px; border-radius: 3px;">
+                            <td> <span class="dev">
                                     <svg class="svg-icon svg-time" aria-hidden="true" focusable="false">
                                         <use xlink:href="/svg-icons/icon-sprite.svg#time"></use>
                                     </svg>
                                     <span>En développement</span>
                                 </span>
                             </td>
-                            <td> <span class="dev" style="padding: 2px 8px; margin-right: 8px; border-radius: 3px;">
+                            <td> <span class="dev">
                                     <svg class="svg-icon svg-time" aria-hidden="true" focusable="false">
                                         <use xlink:href="/svg-icons/icon-sprite.svg#time"></use>
                                     </svg>
                                     <span>En développement</span>
                                 </span>
                             </td>
-                            <td><span class="active" style="padding: 2px 8px; border-radius: 3px;"> <svg
+                            <td><span class="active"> <svg
                                         class="svg-icon svg-valid" style="color:#368E6E;" aria-hidden="true"
                                         focusable="false">
                                         <use xlink:href="/svg-icons/icon-sprite.svg#valid"></use>
@@ -1537,39 +1536,39 @@
                             <th class="pl-1" scope="row">
                                 <p class="m-teaser__type rounded-lg text-uppercase bg-primary text-white">15-NexSIS</p>
                             </th>
-                            <td><span class="active" style="padding: 2px 8px; border-radius: 3px;"> <svg
+                            <td><span class="active"> <svg
                                         class="svg-icon svg-valid" style="color:#368E6E;" aria-hidden="true"
                                         focusable="false">
                                         <use xlink:href="/svg-icons/icon-sprite.svg#valid"></use>
                                     </svg>
                                     En production</span></td>
-                            <td>                                <span class="test" style="padding: 2px 8px; margin-right: 8px; border-radius: 3px;">
+                            <td> <span class="test">
                                     <svg class="svg-icon svg-play" aria-hidden="true" focusable="false">
                                         <use xlink:href="/svg-icons/icon-sprite.svg#play"></use>
                                     </svg> Tests ANS validés</span>
                             </td>
-                            <td> <span class="dev" style="padding: 2px 8px; margin-right: 8px; border-radius: 3px;">
+                            <td> <span class="dev">
                                     <svg class="svg-icon svg-time" aria-hidden="true" focusable="false">
                                         <use xlink:href="/svg-icons/icon-sprite.svg#time"></use>
                                     </svg>
                                     <span>En développement</span>
                                 </span>
                             </td>
-                            <td> <span class="dev" style="padding: 2px 8px; margin-right: 8px; border-radius: 3px;">
+                            <td> <span class="dev">
                                     <svg class="svg-icon svg-time" aria-hidden="true" focusable="false">
                                         <use xlink:href="/svg-icons/icon-sprite.svg#time"></use>
                                     </svg>
                                     <span>En développement</span>
                                 </span>
                             </td>
-                            <td> <span class="dev" style="padding: 2px 8px; margin-right: 8px; border-radius: 3px;">
+                            <td> <span class="dev">
                                     <svg class="svg-icon svg-time" aria-hidden="true" focusable="false">
                                         <use xlink:href="/svg-icons/icon-sprite.svg#time"></use>
                                     </svg>
                                     <span>En développement</span>
                                 </span>
                             </td>
-                            <td><span class="active" style="padding: 2px 8px; border-radius: 3px;"> <svg
+                            <td><span class="active"> <svg
                                         class="svg-icon svg-valid" style="color:#368E6E;" aria-hidden="true"
                                         focusable="false">
                                         <use xlink:href="/svg-icons/icon-sprite.svg#valid"></use>
@@ -1583,12 +1582,12 @@
                     <div class="o-paragraph--mixed-push__slider col--eq-height">
 
                         <article class="m-teaser--service mb-3 tns-item tns-slide-active" id="tns1-item0">
-                            <div
-                                class="bg-gray-700 text-white rounded-md top-left-radius-0 text-center py-4 px-3">
+                            <div class="bg-gray-700 text-white rounded-md top-left-radius-0 text-center py-4 px-3">
                                 <h3 class="m-teaser__title h4">15-SMUR</h3>
 
                                 <div class="wysiwyg mb-3">
-                                    <p>Le lien est prêt pour une implémentation par les éditeurs de LRM et de tablettes</p>
+                                    <p>Le lien est prêt pour une implémentation par les éditeurs de LRM et de tablettes
+                                    </p>
                                     <p>Le premier déploiement dans un SAMU est prévu en septembre 2026</p>
                                 </div>
 
@@ -1598,12 +1597,12 @@
                             </div>
                         </article>
                         <article class="m-teaser--service mb-3 tns-item tns-slide-active" id="tns1-item0">
-                            <div
-                                class="bg-gray-700 text-white rounded-md top-left-radius-0 text-center py-4 px-3">
+                            <div class="bg-gray-700 text-white rounded-md top-left-radius-0 text-center py-4 px-3">
                                 <h3 class="m-teaser__title h4">15-SICAP</h3>
 
                                 <div class="wysiwyg mb-3">
-                                    <p>L'identification des sites pilotes et l'implémentation par les éditeurs de LRM est en cours</p>
+                                    <p>L'identification des sites pilotes et l'implémentation par les éditeurs de LRM
+                                        est en cours</p>
                                     <p>Le premier déploiement dans un SAMU est prévu en septembre 2026</p>
                                 </div>
 
@@ -1613,12 +1612,12 @@
                             </div>
                         </article>
                         <article class="m-teaser--service mb-3 tns-item tns-slide-active" id="tns1-item0">
-                            <div
-                                class="bg-gray-700 text-white rounded-md top-left-radius-0 text-center py-4 px-3">
+                            <div class="bg-gray-700 text-white rounded-md top-left-radius-0 text-center py-4 px-3">
                                 <h3 class="m-teaser__title h4">15-Portail SI-SAMU</h3>
 
                                 <div class="wysiwyg mb-3">
-                                    <p>Le premier jalon fonctionnel identifié est le partage des dossiers du portail SI-SAMU vers le 15</p>
+                                    <p>Le premier jalon fonctionnel identifié est le partage des dossiers du portail
+                                        SI-SAMU vers le 15</p>
                                     <p>Le raccordement du Portail SI-SAMU au Hub Santé est prévu en septembre</p>
                                 </div>
 

--- a/web/landing/pages/travaux.html
+++ b/web/landing/pages/travaux.html
@@ -99,99 +99,95 @@
                                             data-parent="#menuPrincipal">
                                             <div class="nav-collapse-inner">
                                                 <ul class="navbar-nav nav-lvl--2">
+                                                    <li class="nav-item common-nav-item">
+                                                        <a class="nav-link" href="/pages/actualites.html">Actualités</a>
+                                                    </li>
                                                     <li class="nav-item common-nav-item is-active">
                                                         <a class="nav-link" href="/pages/travaux.html">Travaux en
                                                             cours</a>
-                                                    <li class="nav-item common-nav-item">
-                                                        <a class="nav-link" href="/pages/rdv.html">Les RDV du Hub</a>
-                                                    <li class="nav-item common-nav-item">
-                                                        <a class="nav-link" href="/pages/webinaires.html">Le Hub en
-                                                            replay</a>
                                                     </li>
-
+                                                </ul>
+                                            </div>
+                                        </div>
+                                    </li>
+                                    <li class="nav-item common-nav-item">
+                                        <button class="nav-link" type="button" data-toggle="collapse"
+                                            data-target="#nav1-nav-collapse-submenu--2"
+                                            aria-controls="nav1-nav-collapse-submenu--2"
+                                            aria-expanded="false">Accompagnement</button>
+                                        <div class="collapse nav-collapse" id="nav1-nav-collapse-submenu--2"
+                                            data-parent="#menuPrincipal">
+                                            <div class="nav-collapse-inner">
+                                                <ul class="navbar-nav nav-lvl--2">
+                                                    <li class="nav-item common-nav-item ">
+                                                        <a class="nav-link" href="/pages/parcours.html">Se raccorder au
+                                                            Hub</a>
+                                                    </li>
+                                                    <li class="nav-item common-nav-item">
+                                                        <a class="nav-link" href="/pages/accompagnement.html">Ressources
+                                                            éditeurs</a>
+                                                    </li>
+                                                </ul>
+                                            </div>
+                                        </div>
+                                    </li>
+                                    <li class="nav-item common-nav-item">
+                                        <a class="nav-link" href="/pages/faq.html">FAQ</a>
+                                    </li>
+                                    <li class="nav-item common-nav-item">
+                                        <a class="nav-link" href="/pages/contacts.html">Contacts</a>
                                     </li>
                                 </ul>
+                            </nav>
+                            <ul class="nav-right">
+                                <li class="nav-right-item collapse-wrapper common-nav-item">
+                                    <button type="button" class="btn btn--icon-only btn-icon--header"
+                                        aria-label="Accessibilité" data-toggle="collapse" data-target="#collapseAccess"
+                                        aria-controls="collapseAccess" aria-expanded="false">
+                                        <svg class="svg-icon svg-access" aria-hidden="true" focusable="false">
+                                            <use xlink:href="/svg-icons/icon-sprite.svg#access"></use>
+                                        </svg>
+                                        <span class="title-responsive">Accessibilité</span>
+                                    </button>
+                                    <div class="collapse nav-collapse nav-collapse--right" id="collapseAccess">
+                                        <section aria-labelledby="widget-access-title">
+                                            <h2 class="o-widget-access__intro" id="widget-access-title">Options
+                                                d'accessibilité</h2>
+
+                                            <div class="o-widget-access">
+                                                <div class="form-group form-group-custom-control">
+                                                    <fieldset id="contrast-id">
+                                                        <legend>Contrastes :</legend>
+
+                                                        <div class="o-widget-access__option">
+                                                            <input id="default-c" value="default-c" name="contrast"
+                                                                checked="checked" type="radio" class="sr-only">
+                                                            <label
+                                                                class="o-widget-access__label btn btn--ghost btn--primary btn-sm"
+                                                                for="default-c"><span class="sr-only">Contrastes</span>
+                                                                Standards</label>
+                                                        </div>
+                                                        <div class="o-widget-access__option">
+                                                            <input id="high-c" value="high-c" name="contrast"
+                                                                type="radio" class="sr-only">
+                                                            <label
+                                                                class="o-widget-access__label btn btn--ghost btn--primary btn-sm"
+                                                                for="high-c"><span class="sr-only">Contrastes</span>
+                                                                Renforcés</label>
+                                                        </div>
+                                                    </fieldset>
+                                                </div>
+
+
+                                            </div>
+                                        </section>
+                                    </div>
+                                </li>
+                            </ul>
                         </div>
                     </div>
-                    </li>
-
-                    <li class="nav-item common-nav-item">
-                        <button class="nav-link" type="button" data-toggle="collapse"
-                            data-target="#nav1-nav-collapse-submenu--2" aria-controls="nav1-nav-collapse-submenu--2"
-                            aria-expanded="false">Accompagnement</button>
-                        <div class="collapse nav-collapse" id="nav1-nav-collapse-submenu--2"
-                            data-parent="#menuPrincipal">
-                            <div class="nav-collapse-inner">
-                                <ul class="navbar-nav nav-lvl--2">
-                                    <li class="nav-item common-nav-item ">
-                                        <a class="nav-link" href="/pages/parcours.html">Se raccorder au Hub</a>
-                                    <li class="nav-item common-nav-item">
-                                        <a class="nav-link" href="/pages/accompagnement.html">Ressources éditeurs</a>
-
-
-                                    </li>
-                                </ul>
-                            </div>
-                        </div>
-
-                    </li>
-                    <li class="nav-item common-nav-item">
-                        <a class="nav-link" href="/pages/faq.html">FAQ</a>
-                    </li>
-                    <li class="nav-item common-nav-item">
-                        <a class="nav-link" href="/pages/contacts.html">Contacts</a>
-                    </li>
-                    </ul>
-                    </nav>
-                    <ul class="nav-right">
-                        <li class="nav-right-item collapse-wrapper common-nav-item">
-                            <button type="button" class="btn btn--icon-only btn-icon--header" aria-label="Accessibilité"
-                                data-toggle="collapse" data-target="#collapseAccess" aria-controls="collapseAccess"
-                                aria-expanded="false">
-                                <svg class="svg-icon svg-access" aria-hidden="true" focusable="false">
-                                    <use xlink:href="/svg-icons/icon-sprite.svg#access"></use>
-                                </svg>
-                                <span class="title-responsive">Accessibilité</span>
-                            </button>
-                            <div class="collapse nav-collapse nav-collapse--right" id="collapseAccess">
-                                <section aria-labelledby="widget-access-title">
-                                    <h2 class="o-widget-access__intro" id="widget-access-title">Options
-                                        d'accessibilité</h2>
-
-                                    <div class="o-widget-access">
-                                        <div class="form-group form-group-custom-control">
-                                            <fieldset id="contrast-id">
-                                                <legend>Contrastes :</legend>
-
-                                                <div class="o-widget-access__option">
-                                                    <input id="default-c" value="default-c" name="contrast"
-                                                        checked="checked" type="radio" class="sr-only">
-                                                    <label
-                                                        class="o-widget-access__label btn btn--ghost btn--primary btn-sm"
-                                                        for="default-c"><span class="sr-only">Contrastes</span>
-                                                        Standards</label>
-                                                </div>
-                                                <div class="o-widget-access__option">
-                                                    <input id="high-c" value="high-c" name="contrast" type="radio"
-                                                        class="sr-only">
-                                                    <label
-                                                        class="o-widget-access__label btn btn--ghost btn--primary btn-sm"
-                                                        for="high-c"><span class="sr-only">Contrastes</span>
-                                                        Renforcés</label>
-                                                </div>
-                                            </fieldset>
-                                        </div>
-
-
-                                    </div>
-                                </section>
-                            </div>
-                        </li>
-                    </ul>
                 </div>
             </div>
-        </div>
-        </div>
         </div>
     </header>
 
@@ -230,8 +226,9 @@
                     <div class="o-banner__content">
                         <h1>Les travaux en cours </h1>
                         <p class="lead">Tenez-vous informé.</p>
-                        <p>Retrouvez l’ensemble des périmètres d'échanges actuellement à l'étude sur le Hub Santé et
-                            suivez leur progression ci-dessous.</p>
+                        <p>Retrouvez l’etat d'avancement des développements et des raccordements en production au Hub
+                            Santé sur le catalogue de
+                            liens disponibles.</p>
 
                         <div class="o-banner__share-links d-none d-lg-inline-flex">
                             <ul class="list-unstyled d-lg-inline-flex"> </ul>
@@ -255,285 +252,1393 @@
             <div class="bg-gray-400 pt-2 pb-2">
 
                 <div class="container paragraph-title-text text-center text-default">
-                    <h2>Périmètres d'échanges </h2>
-
+                    <h2>Découvrez le catalogue des liens disponibles via le Hub Santé </h2>
                     <div class="wysiwyg text-center mt-2 mb-2">
-                        <p> Nous organisons régulièrement des réunions et webinaires pour échanger sur l'avancement
-                            des travaux : n'hésitez pas à consultez nos rubriques <a href="/pages/rdv.html"
-                                target="_blank"> <i>Les RDV du Hub</i>.</a> et <a href="/pages/webinaires.html"
-                                target="_blank"> <i>le Hub en Replay</i>.</a>
-
-                            Le nouveau badge Hub Santé facilite la communication des éditeurs partenaires qui ont
-                            implémenté
-                            au moins l'intégralité d'un périmètre d'échange.
-                        <div class="container" style="display: flex; justify-content: space-around; flex-wrap: wrap;">
-                            <a href="/pages/parcours.html#etape7" class="btn btn--style1 btn--white mt-1"
-                                target="_blank">
-                                Badge Hub Santé </a>
-
-                        </div>
-                        </p>
-
+                       Le Hub Santé offre la possibilité d'échanger des données dans les liens suivants :
                     </div>
+                </div>
+                <div class="container" style="display: flex; justify-content: space-around; flex-wrap: wrap;">
+
+
+                    <a href="/resources/Liens/Lien_15-15.pdf" class="btn btn--style1 btn--white mt-1" target="_blank">
+                        15-15 </a>
+
+
+                    <a href="/resources/Liens/Lien_15-NexSiS.pdf" class="btn btn--style1 btn--white mt-1" target="_blank">
+                        15-NexSIS </a>
+
+
+                    <a href="/resources/Liens/Lien_15-SMUR.pdf" class="btn btn--style1 btn--white mt-1" target="_blank">
+                        15-SMUR </a>
+
+
+                    <a href="/resources/Liens/Lien_15-CAP.pdf" class="btn btn--style1 btn--white mt-1" target="_blank">
+                        15-SICAP </a>
                 </div>
             </div>
 
-            <!-- Titre 15-15 -->
-            <div class="bg-white" id="15-15">
+
+            <!-- Titre Prod -->
+            <div class="bg-white" id="production">
                 <div class="container paragraph-space paragraph--title-text text-center pt-2 pb-1">
-                    <h1>15-15</h1>
+                    <h1>Les acteurs en production</h1>
                 </div>
             </div>
 
-            <!-- Bannière Enjeux 15-15 -->
-            <div class="container paragraph-space">
-                <div class="row">
-                    <div class="col-md-8 mb-3">
-                        <h2>Les enjeux du 15-15 </h2>
-                        <div class="wysiwyg mb-3">
-                            <ul>
-                                <li>Améliorer la coopération des SAMU, fluidifier et simplifier leurs échanges en
-                                    facilitant l’interopérabilité des LRM.
-                                </li>
-                                <li>Gagner en efficacité, réduire les temps d’attente et les risques d’erreurs lors des
-                                    traitements des appels d’urgence.
-                                </li>
-                                <li>Améliorer la réversibilité des marchés publics et permettre aux SAMU de choisir la
-                                    solution logicielle qui leur convient le mieux; tout en restant maîtres de leurs
-                                    données.
-                                </li>
-                            </ul>
-                        </div>
+            <div class="row" style="width: 90%; padding-left: 10%">
+                <div id="div-map" class="col-lg-7" style="display: flex; justify-content: center">
+                    <svg version="1.1" id="svg2" xmlns:cc="http://web.resource.org/cc/"
+                        xmlns:dc="http://purl.org/dc/elements/1.1/"
+                        xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg"
+                        xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+                        preserveAspectRatio="xMinYMin meet" viewBox="0 0 680 553" style="width: 100%; height: 100%"
+                        xml:space="preserve">
+                        <g id="complete_map">
+                            <a class="department" id="dep-2A" data-num-dep="2A">
+                                <title>2A - Corse-du-Sud</title>
+                                <path d="M445.3,489v2.2l2,1.4l3.3,1.9l0.2,1.6l-2,0.6l-3.1,0.6v1.3l1.2,1.2l0.2,3.9l4.3,1.4l1.6,0.4l1.4,2.2l-1,1.4 l-1.6,0.6l-1.2,2.2l-1.2,1.4l0.6,3.5l2.9-0.2l0.8,0.6l2.8-1.4l0.8,0.8l-1.4,2.9l1.4,1.4l-2.3,1.8l-1.6,3.5l4.3,1l6.1,0.6l-2.5,2.9
+														c0,0-1.2-0.5-1.7-0.2c0,0,0,0-0.1,0c0,0,0,0,0,0c0,0,0,0,0,0c0,0,0,0,0,0c0,0,0,0,0,0c0,0,0,0,0,0c0,0,0,0.1,0,0.1c0,0,0,0,0,0
+														c0,0,0,0,0,0.1c0,0,0,0,0,0.1c0,1-1.3,3.3-1.3,3.3l1.9,2.1l3.5,2.2l6.6,1.8l1.9,0.8l1.8,0.8l-1.2,2.2l3.1-0.2l0.6,1.4h3.1l0.8-3.7
+														l-2-0.4l2.8-2.9l-1-1l0.2-1.8l3.5-1.9l0.2-2.2l-2.3-0.2l-1.6,1.3v-1.9l3.1-0.2l1-2.3l0.8-6.8l-0.6-2.9l-0.1-2.8l-3.4,2.3l-4.1,0.2
+														l-0.3-2.8l0.5-0.7l-1.3-0.9l-0.3-4.8l-0.5-0.9h-2.1l-1.1-0.9v-3.4l-1.4-0.9l-1.1-0.5l-2.1-2.7l0.2-1.6h-2.6l-0.9-2.7h-3.7l-1.9-2.7
+														l0.5-0.9l-1.2-0.7l-2.8,0.5l-1.1-0.7h-3.9l-0.4-1.1l-2.2-0.4H445.3z"></path>
+                            </a>
+                            <a class="department" id="dep-2B" data-num-dep="2B">
+                                <title>2B - Haute-Corse</title>
+                                <path d="M478,449.9l-2.9,2l0.4,1.9l1.6,2l-1.8,1.3l0.8,1.6l-1.2,1.4v1.8l2,1.8v2.7l-1.2,2.5l-1.3,0.6l-1.6-2.2
+														l-2.8,0.2l-0.6-0.4H467l-2.1,2l-0.8,3.3l-5.1,1l-3.9,3.3l-0.8,2.2l-1.9-0.2l-1-1.2l-0.6,3.3l-1.4,0.6l-0.4,3.1l0.6,1.4l-2.2,1.6
+														l-0.6,1.6l2.2,0.4l0.4,1.1h3.9l1.1,0.7l2.8-0.5l1.2,0.7l-0.5,0.9l1.9,2.7h3.7l0.9,2.7h2.6l-0.2,1.6l2.1,2.7l1.1,0.5l1.4,0.9v3.4
+														l1.1,0.9h2.1l0.5,0.9l0.3,4.8l1.3,0.9l-0.5,0.7l0.3,2.8l4.1-0.2l3.4-2.3l-0.1-5.8l4.7-6.6v-10.9l-1.9-3.7l-0.6-11.7l-1.4-2.2
+														l-2.5-1.9l-0.4-7.3l1.2-3.3l-1.6-5.3l-1-4.3l-0.8-1.2L478,449.9z"></path>
+                            </a>
+                            <a class="department" id="dep-13" data-num-dep="13">
+                                <title>13 - Bouches-du-Rhône</title>
+                                <path d="M379.7,409.9l-5.5,3.1l-1.4,10.5l-5.8-0.8l-1.7,4.4l1.4,1.9l-6.3,3.9l-1.8,4.1l6.2,0.3l8.2,0.6l1.6,1.6h-2.9
+														l-1.9,3.3l8.4,1.8l6.7-1.2l-3.5-3.3l2.3-1.9l3.7,1.6l1.8,3.7l11.2,0.2l2.9-1.2l0.6,1.8l-3.1,2.7l4.3,0.2l-0.8,2l-1.2,1.4h9.6
+														l4.7,1.6l0.5,0.6l0.2-3.9l1.4-1.6l1.8-1.1l-0.2-1.1l-1.4-1.4h-1.4l-0.9-1.1l1.6-1.4v-0.5l-1.8-0.9v-1.4l3.9,0.2l0.9-0.7l-3.4-3.2
+														l0.2-3.7l-2.1-1.8l1.8-3.5l4.3-2.8l-3.2-2.1l-2.3,1.8l-5.3,1.2l-4.3-0.5l-7.6-3.2l-4.6,0.2l-3.9-1.8l-1.4-2l-3-3.3l-7.1-3
+														L379.7,409.9z"></path>
+                            </a>
+                            <a class="department" id="dep-84" data-num-dep="84">
+                                <title>84 - Vaucluse</title>
+                                <path d="M387,381.3l-2.8,0.2l-2.1,3.3l0.6,3.5l3.3,0.4l-0.6,1.6l-2.6,0.2l-2.9,2.9l-0.8-1l0.6-3.9l-1.2-1.4l-5.3,0.8
+														l-1,2.1l0.6,0.3l3.3,5.5v4.4l5.8,5.8v2.5l-2.3,1.3l0.2,0.1l7.1,3l3,3.3l1.4,2l3.9,1.8l4.6-0.2l7.6,3.2l4.3,0.5l5.3-1.2l2.2-1.7
+														l0.3-1.5l-4.1-4.6H411V413l1.6-1.8v-1.9l-3.5-1.8l-0.3-2.8l1.9-0.9v-2.5l-2.1-0.4l-0.2-2.7l0-0.2l-1.8-0.1l-2.9-2.2l-0.8-2.5
+														l-5.5-0.4l-4.1-0.4l-0.4-2.3l1.4-2.9l-2.5,2.2l-3.9-0.4l-0.8-1.4l2.7-3.7L387,381.3z"></path>
+                            </a>
+                            <a class="department" id="dep-83" data-num-dep="83">
+                                <title>83 - Var</title>
+                                <path d="M457.8,413.2l-3,0.1l-1.4,1.4l-5.3-0.2l-4.6,3.3l-3.2-2.1l-5,1.6l-0.9,1.8l-3.5,2.7l-6.4-4.3l-5.2,1.7
+														l-0.3,1.4l0.1-0.1l3.2,2.1l-4.3,2.8l-1.8,3.5l2.1,1.8l-0.2,3.7l3.4,3.2l-0.9,0.7l-3.9-0.2v1.4l1.8,0.9v0.5l-1.6,1.4l0.9,1.1h1.4
+														l1.4,1.4l0.2,1.1l-1.8,1.1l-1.4,1.6l-0.2,3.9l0.5,0.7l3.5,1.6l1,3.9l2.2,0.4l2-1.4l3.5-2.2l6.1,0.6l-0.2,1.6l-2,1l4.7,0.2l-1.2-1.2
+														l-0.4-2.5l2.5-1.8l2.9,1l1.2,0.4l1,1.2l1.4-1l0.4-2.6l1.6-1.3h4.1l1.2-1.8l2.7,0.8l3.1-1.3v-5.1l-4.1,0.2l3.1-1.9l1.6-2.2l0.4-3.1
+														l5.7-0.8l3.2-3.5l-2.2-2.3v-1.3l-1.1-1.1l1.4-1.2l-0.3-2l-2.3-0.9h-1.2l-2.1-2.1l-0.4-3.7l-2.3-1.1l-2.3-0.2l-0.9-2.1L457.8,413.2z
+														"></path>
+                            </a>
+                            <a class="department" id="dep-04" data-num-dep="04">
+                                <title>04 - Alpes-de-Haute-Provence</title>
+                                <path d="M463.8,364.3l-2.1,3.2l-3,1.8l-1.1,2.1l-2.7,0.2v1.9l-0.7,1.1l-1.1,2.7l-6.3-0.2l-3-1.6l-2,1.4l-3.7-0.2
+														l-0.9,1.3h0.9l0.5,3.3l-0.9,0.4l-3.3-2.1v-1.3l-1.9-1.6h-1.1v1.8l-1.6,0.3l-3.4,1.9l-2.1,3.6l-0.5,1.8l1.3,0.3l0.2,2.8h-1.3
+														l-1.9-1.8l-1.1,0.2l0.5,1.6l3,3.3l-1.9,0.7l-1.4-0.9h-3.6l-3,2.8l0,0l-0.1,1.2l-1.2-1.4l-1.6-1.4l-1,2.9l-1.8,1.6l-0.8-0.1l0,0.2
+														l0.2,2.7l2.1,0.4v2.5l-1.9,0.9l0.3,2.8l3.5,1.8v1.9L411,413v1.6h4.4l4.1,4.6l0,0.1l5.2-1.7l6.4,4.3l3.5-2.7l0.9-1.8l5-1.6l3.2,2.1
+														l4.6-3.3l5.3,0.2l1.4-1.4l3-0.1l0.1,0l-0.7-1.8l0.9-1.1l-0.3-1.4h2.8l0.7-0.9l2.7-1.4l2.1,1.4l1.4-0.9l-3.3-3l-3.6-3.3l-1.2-0.4
+														l-0.2-2.7l-2.1-3.2l0.7-4.6l1.1-2.5l1.9-1.6l0.2-2.5l2.7-1.4l0.4-0.2v-3.8l2.8-0.4l-1.6-1.4l-2-0.6l-1-2.5l0.8-1.8l3.5-3.7
+														l-0.6-2.8l0.5-0.5L463.8,364.3z"></path>
+                            </a>
+                            <a class="department" id="dep-06" data-num-dep="06">
+                                <title>06 - Alpes-Maritimes</title>
+                                <path
+                                    d="M463.9,381.9l-0.4,0.2l-2.7,1.4l-0.2,2.5l-1.9,1.6l-1.1,2.5l-0.7,4.6l2.1,3.2l0.2,2.7l1.2,0.4l3.6,3.3l3.3,3
+														L466,408l-2.1-1.4l-2.7,1.4l-0.7,0.9h-2.8l0.3,1.4l-0.9,1.1l0.7,1.8l-2.3,1.4l0.9,2.1l2.3,0.2l2.3,1.1l0.4,3.7l2.1,2.1h1.2l2.3,0.9
+														l0.3,2l-1.4,1.2l1.1,1.1v1.3l2.2,2.3l0.2-0.2l0.2-4.5l3.9,0.8l1.4-1.8l2,0.4l0.2-6.1l4.5-0.4l3.9-3.5h3.5l0.2-2.2l3.5-2.1l-2-4.5
+														l2.9-2.5l-0.6-2.9l4.3-1.4l1.2-4.3l-0.6-2.9l-1-1.8l-0.8-2.6l-2.9,0.2l-9.2,3.3h-2.9l-5.1-4.1l-5.1-1.4H468v-3.5l-4.1-2.5V381.9z">
+                                </path>
+                            </a>
+                            <a class="department" id="dep-05" data-num-dep="05">
+                                <title>05 - Hautes-Alpes</title>
+                                <path
+                                    d="M447.3,339.2l-1.8,0.8l-0.4,2.9l-3.5,0.4l-0.6-2.8l-1.2-1.2l-3.5,0.4l-1.4,1.2l-0.8,4.1l0.6,1l4.1,0.4l0.8,2.5
+														l1.6,0.8v4.3l-3.7-0.2l-1.6,1.8l-4.5-0.8l-2.5,2.2l-1.8-0.8l-2.5,2l1,1.8l-1.6,1.6h-4.9v2.3l1.6,0.8l-0.6,1.4l-3.3,1.3l-4.1,0.4
+														l-1.2,3.7l-0.2,2.3l2.2,1.8l-2.2,2.5l-2.7-1.4l-3.1-0.2l-0.4,1.8l2,1.4l-2.4,1.6l0.8,3.3l6.6,1.8l1.2,2.5l1.9,0.4l-0.7,6.1l0,0
+														l3-2.8h3.6l1.4,0.9l1.9-0.7l-3-3.3l-0.5-1.6l1.1-0.2l1.9,1.8h1.3l-0.2-2.8l-1.3-0.3l0.5-1.8l2.1-3.6l3.4-1.9l1.6-0.3v-1.8h1.1
+														l1.9,1.6v1.3l3.3,2.1l0.9-0.4l-0.5-3.3h-0.9l0.9-1.3l3.7,0.2l2-1.4l3,1.6l6.3,0.2l1.1-2.7l0.7-1.1v-1.9l2.7-0.2l1.1-2.1l3-1.8
+														l2.1-3.2l2.5,0.1l1.8-2l2.1,0.2v-1.8l-2.7-1.4l-0.6-5.7l-2.2-0.8l-2.7,0.4l-5.1-2.6l-0.8-5.8l-2.9-1l-1-2l-1.3-2.8L447.3,339.2z">
+                                </path>
+                            </a>
+                            <a class="department" id="dep-48" data-num-dep="48">
+                                <title>48 - Lozère</title>
+                                <path
+                                    d="M320.8,352.3l-5.5,2l-1.6,3.5l-3.5-2.3l-2.8,8.6l-2.8,6.5l4.1,5l-0.3,3.9l2.8,1.9v4.7l0.8,6.6l3.3,1.4
+														l-0.3,2.2l4.7-0.8l1.7,0.8l-1,0.9l6,4l5.2-1.1l0.9-1.3l-0.7-1.8l2.1-0.5l3,2.8l5.1,0.5l2.3-3.5v-3l1.4-1.6l-1.3-0.3v-4.1l-2.8-3
+														l2.3-0.4l1.2-1.1l1-1.9l-1-0.6l0.6-4.1l-3.3-3.6l-1.4-7.2l-5-6.3l-3.6,0.9l-0.8-2.7h-2l-0.4,2.3l-5.1,1.6L320.8,352.3z">
+                                </path>
+                            </a>
+                            <a class="department" id="dep-03" data-num-dep="03">
+                                <title>03 - Allier</title>
+                                <path
+                                    d="M301.6,248l-2.7,3.5l-1.6,0.2l-1.8,1.8l-2-2.2l-5.3,5.3v3.1l1,0.8l0.2,1.6l-2.7,2.1l-2.6-0.8l-4.9,1l-2.5,2.9
+														l-0.9,2l0.2,0l2.3,3.3v2.3l1.3,1.8l1.4-1.8l1.6,2.8l2.2,0.8l2.2,5.1l0.1,1.5l3,2.3l1.6-0.7l1.3-3l1.2-0.3v-1.6l2.1-0.2l0.2,1.1
+														l2.7-3h3l0.5,1.1l-1.4,1.9l2.1,2.3l0.4,1.4l4.9,2.8l6,0.9l1.8-0.2l2.7,0.5l2.3-1.4l1.8,0.9l0.3,2.5l2.3,0.5l3-0.2l0.9,2.1l2.8,1.1
+														l0.1-1l4.7-0.2l-0.4-11.1l-1.4-2.7l0.6-2.2l3.3-0.6l0.1-0.2l4.1-3.1l0.2-7.6l-1.4-1.9h-3.1l-1.2-1.6h-3.3l-1-1.2v-2.9l-3.9-7.4
+														l-1.9-1.4l-3.7,5.1l-1.6,0.4l-0.6-2.5l-1.8-0.8l-0.8,1.6h-2.9l-0.4-1.8l-2,1.2L312,255l-2.3-2.6l-3.3-1.6l-0.2-2.5L301.6,248z">
+                                </path>
+                            </a>
+                            <a class="department" id="dep-30" data-num-dep="30">
+                                <title>30 - Gard</title>
+                                <path d="M346.2,381l-1,1.9L344,384l-2.3,0.4l2.8,3v4.1l1.3,0.3l-1.4,1.6v3l-2.3,3.5l-5.1-0.5l-3-2.8l-2.1,0.5l0.7,1.8
+														l-0.9,1.3l-5.2,1.1l-6-4l-1.2,1v2.8l-2.2,0.5l0.6,2.2l2.8,0.6h3l0.8,3.8l-3.6,1.7v1.8l2.8,1v1.6l1.3,0.7l1.1-0.9h1.4l0.7,1.6h2.1
+														l1.1-3.7h1.8l2.7-3.3l3.2,0.3l0.5,4.6l1.2,1.4l2-1.1l3.3,1.8l1.3,2.1l5.8,3.5l2.1,5v2.6l-3.7,2.1l-2.4,2.2l3,0.2v3.9l4.5-0.2
+														l2.4,0.1l1.8-4.1l6.3-3.9l-1.4-1.9l1.7-4.4l5.8,0.8l1.4-10.5l7.7-4.4v-2.5l-5.8-5.8v-4.4l-3.3-5.5l-6.9-3.9l-0.5,3l-2.8,0.3l-0.8-3
+														l-2.8,0.5l-0.5,3.9l-2.2-0.8l-4.7-3.1l-2.2,1.1v-5.5L346.2,381z"></path>
+                            </a>
+                            <a class="department" id="dep-11" data-num-dep="11">
+                                <title>11 - Aude</title>
+                                <path d="M274.3,438.5l-0.3,3.6l-3.6-1.1h-3.9l0.3-1.4l-1.9,0.3l-4.1,1.4l-1.4-2.5l-2.8,2.5l0.8,1.9l-3.1,1.4l-0.5,3
+														l-2.5,1.1l2.2,2.5l-0.6,1.7l9.7,4.7l0.8,6.7v3.6l0.6,4.7h-5l-1.4,1.9l6.3,5.3l3.6-1.9l4.4,5.3l-0.7,0.1l0.8,0.5l7.9-3.9l-1.9-2.8
+														l-0.2-3.3h18.5l-0.3-2.5l4.3-2.3l4.9,3.9l2.6,1.2l-0.2-5.6l0.2-6.4l-2.3,0.2l-2-2.9l1.6-2.6l3.3,3.1l2.9-2.3l2-1.9l0.3-2.1
+														l-2.5-0.1l-0.9-2.8l-2.5-0.2l-2.3-3.4l-1.8,0.2l-2.1-1.3l-0.4-3l-1.1,0.5l0.5,2.1h-2.5l-0.2,3.5l-3.7,1.3l-1.8-3.7l-2.5,1.6
+														l-2.1-1.6l-1.1-2.5l1.8-2.1l-0.8-2.3l-0.2,0.1H282l-6.1-1.1H274.3z"></path>
+                            </a>
+                            <a class="department" id="dep-34" data-num-dep="34">
+                                <title>34 - Hérault</title>
+                                <path d="M335.5,408.4l-2.7,3.3h-1.8l-1.1,3.7h-2.1l-0.7-1.6h-1.4l-1.1,0.9l-1.3-0.7v-1.6l-2.8-1v1l-3.3,0.5l-1.7,1.4
+														l0.5,3.3h-3l-3-1.7h-1.7v1.9l0.3,5.8h-3.3h-1.7l-1.1,2.2l-7.2,2.5l-2.8-1.9l-1.7,2.5l-0.8,2.8l3,2.8l-1.1,3.6l-4.2,1.3l0.8,2.3
+														l-1.8,2.1l1.1,2.5l2.1,1.6l2.5-1.6l1.8,3.7l3.7-1.3l0.2-3.5h2.5l-0.5-2.1l1.1-0.5l0.4,3l2.1,1.3l1.8-0.2l2.3,3.4l2.5,0.2l0.9,2.8
+														l2.5,0.1l0.1-1.1l7-2.2l0.8-1.8l5.5-0.2l1.8-2.2l10.6-8.4l6.6-4.7l2.7,0.2l2.4-2.2l3.7-2.1v-2.6l-2.1-5l-5.8-3.5l-1.3-2.1l-3.3-1.8
+														l-2,1.1l-1.2-1.4l-0.5-4.6L335.5,408.4z"></path>
+                            </a>
+                            <a class="department" id="dep-66" data-num-dep="66">
+                                <title>66 - Pyrénées-Orientales</title>
+                                <path d="M300.5,468.7l-4.3,2.3l0.3,2.5h-18.5l0.2,3.3l1.9,2.8l-7.9,3.9l-0.8-0.5l-6.5,0.5l-0.8,1.7l-3.3,0.8l-2.2,1.9
+														l-6.1,1.4l0.3,2.1l2.9,2.8l5.8,1.6l0.2,3.5l3.1,2.8l2.3-0.4l3.3-4.1l4.1-0.8l6.4,2.2l5.5,4.7l1.6-2h1.4l1.4,1l1.2-0.6l0.2-2.8
+														l5.9-1.4l1.9-2.5l2.9-1h4.1l2.6,2.7l3.1,0.2v-3.1l-1.6-2.2l-2.8-1.2l-0.4-17.1l-2.6-1.2L300.5,468.7z">
+                                </path>
+                            </a>
+                            -
+                            <a class="department" id="dep-15" data-num-dep="15">
+                                <title>15 - Cantal</title>
+                                <path d="M285.8,323.7l-0.6,2.2l1,2.3l-1.2,1.4h-1.9l-2-2.2l-1.8-1l-0.2,5.5l-3.5,2.2l-2.5,3.5l0.6,3.5l-0.8,1.6l-1,3.1
+														h-1.6l-1.6,1.9l1.2,1.2l0.8,1.9l-2.5,1.8l1,6.5l3.3,2.5l-2.5,5.8l2.5,1.1l-1.1,3.3l2.2,0.3l1.7-2.8h2.8l0.5,0.8h6.1l1.1-2.5
+														l1.4-0.6l0.6-4.4h1.4v-4.7l5.5-4.7l0.6,0.8l0.5,3.6l3.9-0.6l0.8,5.5h1.9l0.6,5.5l1.7,2.1l2.8-6.5l2.8-8.6l3.5,2.3l1.6-3.5l5-1.8
+														v-1.7l-1.1-1.6l-2.1-1.3l1.1-1.6l-0.9-0.9l1.1-0.3l1.3-1.1l-2.1-0.2l-1.1-1.4l-0.3-3.7l-1.3-1.3l-0.9-3.2h-4.4l-0.9-2.5l-1.4-0.2
+														l-0.7,1.4l-2.8-0.2l-2.7-4.1l-1.1-0.2l-2.1-1.1l-1.3,1.2h-3.2l-1.6-3.3L285.8,323.7z"></path>
+                            </a>
+                            <a class="department" id="dep-43" data-num-dep="43">
+                                <title>43 - Haute-Loire</title>
+                                <path d="M317.8,326.3l-1.4,0.7v1.2l-2.1,0.2l-1.9,1.6l-3.5,0.5l-0.8,1.2l0.6,0.1l0.9,2.5h4.4l0.9,3.2l1.3,1.3l0.3,3.7
+														l1.1,1.4l2.1,0.2l-1.3,1.1l-1.1,0.3l0.9,0.9l-1.1,1.6l2.1,1.3l1.1,1.6v1.7l0.5-0.2l3.5,9l5.1-1.6l0.4-2.3h2l0.8,2.7l3.6-0.9
+														l4.5,5.8l2.8-4.5l5.1-3.7h4.7l1.6-4.9l3.1-0.2l0.2-3.7h2.9l-0.6-1.4l-0.8-2.5l1.2-2l2.8-1.2l1.2-4.7l-2.5-2.9l-3.1,0.2l0.4-3.7
+														l-6.3-2.7l-2.1,0.2l-4.3,3.5l-3.9-1.3l-0.8,0.8l-2.5-0.7l-1.8-1.8l-1.1,2.1l-3-0.2l-1.4-1.3l-1.1,2.5l-1.9-0.9l-1.3-2.3h-1.6
+														l-1.4-1.2l-2.1,0.9l-2.5,0.2l-1.4-0.9l-0.9,0.5L317.8,326.3z"></path>
+                            </a>
+                            <a class="department" id="dep-63" data-num-dep="63">
+                                <title>63 - Puy-de-Dôme</title>
+                                <path d="M299.1,279.5l-2.7,3l-0.2-1.1l-2.1,0.2v1.6l-1.2,0.3l-1.3,3l-1.6,0.7l-3-2.3l0.3,4.6l1.6,1.9l0.8,3.7l-2.3,1.8
+														l-0.6,2.8l-2.2,1.2l-3.7,2.2l0.4,1.8l4.5,4.5l0.4,2.8l-1.8,2.9v2.8l1.2,1.4l0.6,3.3l-0.4,1.3l6,1.8l1.6,3.3h3.2l1.3-1.2l2.1,1.1
+														l1.1,0.2l2.7,4.1l2.8,0.2l0.7-1.4l0.8,0.1l0.8-1.2l3.5-0.5l1.9-1.6l2.1-0.2v-1.2l1.4-0.7l0.4,0.9l0.9-0.5l1.4,0.9l2.5-0.2l2.1-0.9
+														l1.4,1.2h1.6l1.3,2.3l1.9,0.9l1.1-2.5l1.4,1.3l3,0.2l1.1-2.1l1.8,1.8l2.5,0.7l0.8-0.8l-1.5-0.5l-0.6-2.3l3.7-3.5l-1.8-6.4l-5.1-3.3
+														l-2.1-5.1l-2.3-3.1l0.6-4.3l1.8-1.8l-3.1-2.5l0.1-0.8l-2.8-1.1l-0.9-2.1l-3,0.2l-2.3-0.5l-0.3-2.5l-1.8-0.9l-2.3,1.4l-2.7-0.5
+														l-1.8,0.2l-6-0.9l-4.9-2.8l-0.4-1.4l-2.1-2.3l1.4-1.9l-0.5-1.1H299.1z"></path>
+                            </a>
+                            <a class="department" id="dep-65" data-num-dep="65">
+                                <title>65 - Hautes-Pyrénées</title>
+                                <path d="M179.2,428.5l-1.9,1l0.3,0l3.3,5.5l-2.2,2l1.6,2.3l2.3,3.5l-1.9,2.5l-3.1,7l-5.3,4.5l1.4,2.8l-1.2,0.8
+														l-2.9-0.6l-0.8,6.4l-1.6,1.2l-0.3,4l0.5-0.3l3.3,2l3.9,2.9l0.4,2.3l3.1,2.5h2.6l6.4-2.8l2.7,3.1l3.7,1l1.4-2.3l1.8,0.8l3.8,0.3
+														l-0.3-10.5h2l1.8,0.9l1.3-1.2l-0.2-1.9l2.5-1.4l-0.9-3.7l-1.1-0.9l-2.1,0.7l1.1-1.8l-0.5-2.3l-3.2-2.3l0.2-1.6l1.8-3l2.3-0.9v-1.3
+														l1.4-2.1l0.9-1.3l-3.6-1.8H199l-0.7-1.4h-2.5l-0.7-1.6h-2.3l-0.7,0.7h-2.7l-0.2-1.6l-2.1-1.4l0.7-0.7l0.3-1.8l-0.5-0.5l-1.1-2.8
+														l-2.3-0.3l-2.3-1.3l0.2-3.3H179.2z"></path>
+                            </a>
+                            <a class="department" id="dep-64A" data-num-dep="64A">
+                                <title>64A - Pyrénées-Atlantiques</title>
+                                <path xmlns="http://www.w3.org/2000/svg"
+                                    d="M142.3,430.1l-2.5,1.9l-4.4-0.3l-0.9,1.3l-1.1-0.4l1.4-1.4l-2.5-1.9l-3,2.7l-5.1,0.3l-5.6-2.8l-0.8,1.4   l-4.5,5.5l-3.5,1.4l-2.5,0.4v2.2l2.3,2.2l3.5,0.2l0.2,2.5l2.8,0.2l0.8-1.8l3.7,1.6l2.3,0.6l0.6,2.3l-1.3,1.2v3.7l-2.8,1.4l-0.2,1.8   l1.8,2l3.1,1l0.6-2.9l1.8-1.9l-0.2,2.5l1.4,2h3.5l1.6,2.1l4.7,0.8l4.5,2.8L142.3,430.1z">
+                                </path>
+                            </a>
+                            <a class="department" id="dep-64B" data-num-dep="64B">
+                                <title>64B - Pyrénées-Atlantiques</title>
+                                <polygon xmlns="http://www.w3.org/2000/svg" class=""
+                                    points="142.3,430.1 146.9,430.3 148.7,429.4 151.5,429.4 152.2,430.3 154.5,429.6 156.6,431.2 159.4,430.3    163.2,429.1 163.7,429.9 169.3,430.1 172.2,428.5 172.3,428.9 177.6,429.3 180.9,434.7 178.8,436.7 180.3,439 182.7,442.5    180.8,445.1 177.6,452.1 172.3,456.6 173.7,459.3 172.5,460.1 169.6,459.5 168.8,466 167.3,467.2 166.9,471.2 163.5,473.1    161.8,474 160.8,473.1 158.8,473.5 156.7,474.6 154.7,472.3 149.7,468.4 149.3,464.3 141.8,464.3 142.1,430.9  ">
+                                </polygon>
+                            </a>
+                            <a class="department" id="dep-40" data-num-dep="40">
+                                <title>40 - Landes</title>
+                                <path d="M139.8,374.4l-6.2,3.2l-1.6,0.1l-3.5,18.6l-4.5,17.2l-1.4,6.7l-1.2,4.7l-2.9,5l5.6,2.8l5.1-0.3l3-2.7l2.5,1.9
+														l-1.4,1.4l1.1,0.4l0.9-1.3l4.4,0.3l2.5-1.9l4.6,0.2l1.8-0.9h2.8l0.7,0.9l2.3-0.7l2.1,1.6l2.8-0.9l3.7-1.3l0.5,0.9l5.7,0.2l2.8-1.6
+														l-1.4-2.4l1.4-3.7l1.9-2.5l-0.6-3.3l1.6-1.6l-2.3-3.9l1.9-2.3l2.2-0.4l1.9,0.8l2.8-2.3l1,2.9l1,1.4l2.2-0.6l-0.2-2.5l0.6-1.4
+														l-0.5-1.2l0.5-3.9l2.1-2.1l-1.1-1.3l-2.3-0.2l-2.7-1l-3.9,0.3l-0.7-4.3l-2.5-3l-1.1-0.3l0.4,3.5v1.1l-3.4,0.2l-3.5-1.2l-0.7-4.4
+														l-2.5-2.7l-1.8-0.2l-0.2-1.6l-1.9-1.3l-3.2-0.9l0.9-1.1v-1.1l-1.1-0.9l-1.2-1.1l-3.6,0.5l-2.1,1.8l-1.4,0.2l-2.3-1.6l-3.4,1.4
+														l-1.6-1.1l1.4-1.8l0.2-2.3L139.8,374.4z"></path>
+                            </a>
+                            <a class="department" id="dep-33" data-num-dep="33">
+                                <title>33 - Gironde</title>
+                                <path
+                                    d="M141.3,315.2l-3.1,4.7l-1,16.4l-2.5,16.6l-1.8,12.9l-0.2,3.3l1.4-4.5l2.7-3.5l3.9,3.5l0.4,1.2l1.2,1.6
+														l-4.9,0.2l-0.8-1.2l-1.9,0.8l-0.4,2.9l-2.2,2.9v4.5l0,0.2l1.6-0.1l6.2-3.2l3.3,1.2L143,378l-1.4,1.8l1.6,1.1l3.4-1.4l2.3,1.6
+														l1.4-0.2l2.1-1.8l3.6-0.5l1.2,1.1l1.1,0.9v1.1l-0.9,1.1l3.2,0.9l1.9,1.3l0.2,1.6l1.8,0.2l2.5,2.7l0.7,4.4l3.5,1.2l3.4-0.2v-1.1
+														l-0.4-3.5l1.1,0.3l2,2.4l3.1-0.5l1.4-1.4l-0.2-1.9l-1.3-1.1l0.4-2h1.9l1.9-1.2l-0.9-1.8l-0.5-2.7l1.4-2.5l3-4.6l1.8-2.1l1.6-0.5
+														l0.3-1.8l-2.1-0.2l-0.9-1.9l0.7-1.9l2.5-0.5l1.8-0.5l2.1-0.3l-0.1-0.1l-0.2-3.9l1.9-1.4l-2.5-1.6l-2.5,3l-6,0.2l-0.5-1.4l-1.8-0.9
+														l1.4-1.8v-1.9l-0.7-1.1v-1.1l1.8-1.1l0.5-3.2l1.1-2.8l-1.1-1.6h-1.9l-1-1.2l-1,2.1l-1.9-1.4l-2.8,1.4l-2.3-0.4l-4.5-4.5l-2.8-0.2
+														l-0.8-6.3l-5.1-0.6l-0.2-2.9l-1,1h-5.8l0.3,1.3l1.4,5.7l0.4,5.7l-1,1.6l-1-4.7l-2.8-10.7l-10-9l0.2-4.1L141.3,315.2z">
+                                </path>
+                            </a>
+                            <a class="department" id="dep-24" data-num-dep="24">
+                                <title>24 - Dordogne</title>
+                                <path d="M209.8,310.5l-1.8,3.1l-2.8,0.4l-0.2,4.7l-9.2,6.3l-0.2,6.8l-3.5,3.5l-1.9,1.8l-3.9-0.4l-2.2,3.7l-0.6,1.2
+														l1,1.2h1.9l1.1,1.6l-1.1,2.8l-0.5,3.2l-1.8,1.1v1.1l0.7,1.1v1.9l-1.4,1.8l1.8,0.9l0.5,1.4l6-0.2l2.5-3l2.5,1.6l-1.9,1.4l0.2,3.9
+														l2.8,2l0.3,3.7l3,1.1l1.8-1.6h3.9l2.1-1.8l1.3,0.2l0.3,1.4h3.9l0.9-1.1l1.4,0.2l1.6,1.8v1.3l-1.4,0.9l0.5,1.3l1.9,0.2l2.5-2.3h2.1
+														l1.4,1.6l3.1,1.3l0.2-0.5l1.8-1.8l0.2-2.9l4.3-0.4l2.8-3.9l-1.2-0.4l-0.2-2.1l3.3-0.4l0.2-1.9l1.6-1l1.8-3.1l-1.8-1.9v-2.2l1.3-1.2
+														l-1.8-2.8l0.2-4.3l-4.3,0.2l-1.8-1.2l1.6-1.9l-2.2-1.8l1.6-2l-1.6-0.8v-2.7l3.9-3.5l-2.2-1.8l-1.2-2.9l-4.1-0.6l-1.4-1l2.9-1.4
+														l-1-1.3l-4.3-0.6l-1-3.9l-6.3-0.6l-1.4,2l-1.3,0.4l-1.8-2.3l0.8-2.2l-1-1.9L209.8,310.5z"></path>
+                            </a>
+                            <a class="department" id="dep-47" data-num-dep="47">
+                                <title>47 - Lot-et-Garonne</title>
+                                <path d="M195.3,363.4l-2.1,0.3l-1.8,0.5l-2.5,0.5l-0.7,1.9l0.9,1.9l2.1,0.2l-0.3,1.8l-1.6,0.5l-1.8,2.1l-3,4.6
+														l-1.4,2.5l0.5,2.7l0.9,1.8l-1.9,1.2h-1.9l-0.4,2l1.3,1.1l0.2,1.9l-1.4,1.4l-3.1,0.5l0.5,0.6l0.7,4.3l3.9-0.3l2.7,1l2.3,0.2l1.1,1.3
+														l-2.1,2.1l-0.5,3.9l0.5,1.2l0.8-1.6l2.3,2l3.1-3.1l1.4,1.9l3.3-0.6l3.5-0.4l1.6-2.8l5.8-0.6l2.9,2.9l1-1l1.9-0.6l-0.8-2.7l2.9-0.8
+														l3.7-0.8l-0.8-2.3l1.2-1.4l1-3.7l-2.2-2.3l1.4-4.5l2.9,1.8l4.3-0.8l-2-4.3l-1.6-5.8l3.9-0.2l0.8-2.1l-3.1-1.3l-1.4-1.6H222
+														l-2.5,2.3l-1.9-0.2l-0.5-1.3l1.4-0.9v-1.3l-1.6-1.8l-1.4-0.2l-0.9,1.1h-3.9l-0.3-1.4l-1.3-0.2l-2.1,1.8h-3.9l-1.8,1.6l-3-1.1
+														l-0.3-3.7L195.3,363.4z"></path>
+                            </a>
+                            <a class="department" id="dep-46" data-num-dep="46">
+                                <title>46 - Lot</title>
+                                <path d="M247.5,347.3l-4.2,1.9l-0.6,0.1l0.1,0.2l-1.3,1.2v2.2l1.8,1.9l-1.8,3.1l-1.6,1l-0.2,1.9l-3.3,0.4l0.2,2.1
+														l1.2,0.4l-2.8,3.9l-4.3,0.4l-0.2,2.9l-1.8,1.8l-1,2.6l-3.9,0.2l1.6,5.8l1.7,3.6l2.5-0.1l0.2,1l-1.4,1.6l1.1,2.1h1.6l1.8,1.9h1.6
+														l1.3-1.4l0.3,0.4v1.8l0.5,2.3l3.7,0.2l3-3.2l1.6-0.2l0.5,0.9l0.9,1.9h1.4l0.5-3.5l3,0.4l1.8-2.1l2.8,0.7l4.3-1.9l0,0.4l1.4-1.4
+														l-1.8-2.7l-0.7-3.5l2.3-1.9l1.1,0.3l3.2-3.5l1.8,0.2l0.7-0.9h3.5l1.3-1.4l0.3-1.1l-1.6-0.2l1.1-3.3l-2.5-1.1l2.5-5.8l-3.3-2.5
+														l-1.1-7.2l-3-0.8l-2.2,2.2l-1.1-1.9l-3.3,3.3l-2.2,0.3l-3.8-5.5L247.5,347.3z"></path>
+                            </a>
+                            <a class="department" id="dep-09" data-num-dep="09">
+                                <title>09 - Ariège</title>
+                                <path d="M237.2,446.4l-1.3,0.9l-0.5,1.1l2.5,1.8l0.7,1.3l-0.5,1l-4.3,0.4l-1.2,1.8l0.2,0.5l1.6,0.5l0.9,1.3l-1.1,1.8
+														l-1.3-0.2l-1.9-1.8l-2.3-0.7l-2.3,0.2l-4.1,2.5l0.2,3.4l1.1,0.7l-0.7,2.6l-4.6,1.3l-1.8,2.1v3.5l0.7,1.1l-1.7,1.5l1.1,0.6l6,1.2
+														h2.6l3.3,4.3l8.4-0.4l3.3,5.3l2.9-1.2l8.6,1.2l0.6,3.6l6.1-1.4l2.2-1.9l3.3-0.8l0.8-1.7l7.2-0.5l-4.4-5.3l-3.6,1.9l-6.3-5.3
+														l1.4-1.9h5l-0.6-4.7v-3.6l-0.8-6.7l-9.7-4.7l0.6-1.7l-1.8-2.1l-1.6,0.7l-2.1,0.3l-3.9-1.8L243,448l1.6,1.9l-0.7,1.6l-3.4-0.3
+														l-0.2-1.8l-2-2.7L237.2,446.4z"></path>
+                            </a>
+                            <a class="department" id="dep-32" data-num-dep="32">
+                                <title>32 - Gers</title>
+                                <path d="M207.9,401.9l-5.8,0.6l-1.6,2.8l-3.5,0.4l-3.3,0.6l-1.4-1.9l-3.1,3.1l-2.3-2l-1.4,2.9l0.2,2.5l-2.2,0.6l-1-1.4
+														l-1-2.9l-2.8,2.3l-1.9-0.8l-2.2,0.4l-1.9,2.3l2.3,3.9l-1.6,1.6l0.6,3.3l-1.9,2.5l-1.4,3.7l1.6,2.8l4.9,0.3l1.9-1h3l-0.2,3.3
+														l2.3,1.3l2.3,0.3l1.1,2.8l0.5,0.5l-0.3,1.8l-0.7,0.7l2.1,1.4l0.2,1.6h2.7l0.7-0.7h2.3l0.7,1.6h2.5l0.7,1.4h4.8l3.6,1.8l0.3-0.4
+														l1.9-1.1l3.5-4.6l6.6,0.5l2.8,1.9l0.9-1.3l1.4-4.2l1.8-4.1l3.7-1.6l1.8-0.7l-0.5-1.6l-1.8-0.2l-0.7-1.8h-1.4l-2.3-2.3l0.2-1.6l-3-3
+														l-0.5-1.9l-1.9,0.8l-0.5-1.1l1.3-1.9l-1.4-1.4v-2.5l-1.2-1.3l-3.9-0.2v-2.3l2.1-1.6v-1.8l2.3-1.1l-1.3-0.7l-1.4,0.7h-2.8l-0.9-0.8
+														l-0.5,0.2l-1,1L207.9,401.9z"></path>
+                            </a>
+                            <a class="department" id="dep-31" data-num-dep="31">
+                                <title>31- Haute-Garonne</title>
+                                <path d="M245,412.4l-2.8,1.1l-0.9,1.4l-1.1-1.2l-1.9-0.2l-0.4,1.8l-1.2,0.5l1.8,0.9l-1.2,1.9l-4.4,1.3l-1.9-2.3h-1.8
+														l-1.4,0.9h-5.1l-0.5,0.2l0.5,1.9l3,3l-0.2,1.6l2.3,2.3h1.4l0.7,1.8l1.8,0.2l0.5,1.6l-1.8,0.7l-3.7,1.6l-1.8,4.1l-1.4,4.2l-0.9,1.3
+														l-2.8-1.9l-6.6-0.5l-3.5,4.6l-1.9,1.1l-1.3,1.8l-1.4,2.1v1.3l-2.3,0.9l-1.8,3l-0.2,1.6l3.2,2.3l0.5,2.3l-1.1,1.8l2.1-0.7l1.1,0.9
+														l0.9,3.7l-2.5,1.4l0.2,1.9l-1.3,1.2l-1.8-0.9h-2l0.3,10.5l7.9,0.5l0.4-9.6l2.7,0.4l4,2.3l1.7-1.5l-0.7-1.1v-3.5l1.8-2.1l4.6-1.3
+														l0.7-2.6l-1.1-0.7l-0.2-3.4l4.1-2.5l2.3-0.2l2.3,0.7l1.9,1.8l1.3,0.2l1.1-1.8l-0.9-1.3l-1.6-0.5l-0.2-0.5l1.2-1.8l4.3-0.4l0.5-1
+														l-0.7-1.3l-2.5-1.8l0.5-1.1l1.3-0.9l1.2,0.3l2,2.7l0.2,1.8l3.4,0.3l0.7-1.6L243,448l1.1,0.3l3.9,1.8l2.1-0.3l1.6-0.7l-0.4-0.4
+														l2.5-1.1l0.5-3l3.1-1.4l-0.8-1.9l2.8-2.5l1.4,2.5l4.1-1.4l0.8-0.1l0.1-1.3v-2.5l-2.1,0.4l-2.7-0.7l-2.3-2.8l-0.9-1.3l-4.6-1.9
+														l-1.1-1.6l1.4-0.5v-1.9l-1.4-1.6l-1.8-2.8l-0.2-2.5l-0.5-0.3l-2.1-2.5l-0.9-2.6L245,412.4z"></path>
+                            </a>
+                            <a class="department" id="dep-82" data-num-dep="82">
+                                <title>82 - Tarn-et-Garonne</title>
+                                <path d="M220.2,384.7l-1.4,4.5l2.2,2.3l-1,3.7l-1.2,1.4l0.8,2.3l-3.7,0.8l-2.9,0.8l0.8,2.7l-1.5,0.4l0.9,0.8h2.8
+														l1.4-0.7l1.3,0.7l-2.3,1.1v1.8l-2.1,1.6v2.3l3.9,0.2l1.2,1.3v2.5l1.4,1.4l-1.3,1.9l0.5,1.1l2.5-1.1h5.1l1.4-0.9h1.8l1.9,2.3
+														l4.4-1.3l1.2-1.9l-1.8-0.9l1.2-0.5l0.4-1.8l1.9,0.2l1.1,1.2l0.9-1.4l2.8-1.1l1.3,0.6l1-1.7l-1.8-1.9h3.3l1.1-1.9l2.3-2.1h-2.3
+														l0.7-3l6-0.7l2.3-1.4l2.8-1.1l0.9-0.9l-1.1-2.8l1.6-3.2l-2.8-0.2l-0.3-4.4l-4.3,1.9l-2.8-0.7l-1.8,2.1l-3-0.4l-0.5,3.5h-1.4
+														l-0.9-1.9l-0.5-0.9l-1.6,0.2l-3,3.2l-3.7-0.2l-0.5-2.3v-1.8l-0.3-0.4l-1.3,1.4h-1.6l-1.8-1.9h-1.6l-1.1-2.1l1.4-1.6l-0.2-1
+														l-2.5,0.1l0.3,0.7l-4.3,0.8L220.2,384.7z"></path>
+                            </a>
+                            <a class="department" id="dep-12" data-num-dep="12">
+                                <title>12 - Aveyron</title>
+                                <path d="M294.7,353.4l-5.5,4.7v4.7h-1.4l-0.6,4.4l-1.4,0.6l-1.1,2.5h-6.1l-0.5-0.8h-2.8l-1.7,2.8l-0.6-0.1l-0.3,1.1
+														l-1.3,1.4H268l-0.7,0.9l-1.8-0.2l-3.2,3.5l-1.1-0.3l-2.3,1.9l0.7,3.5l1.8,2.7l-1.4,1.4l0.3,4l2.8,0.2l-1.6,3.2l1.3,3.2l1.6-0.9
+														l0.7,1.6l2.3-2.3l3.4-0.2l3.3,2.5l5.8,1.1l2.1,3.7l3,1.4l1.6,4.1l-0.2,1.6l1.9,3.6v1.9l3.5,4.6l3.4,1.8l2.1-0.5l1.1-1.4l1.6,0.4
+														l3.7,2.3h0h1.6h3.3l-0.3-5.8v-1.9h1.7l3,1.7h3l-0.5-3.3l1.7-1.4l3.3-0.5v-2.8l3.6-1.7l-0.8-3.8h-3l-2.8-0.6l-0.6-2.2l2.2-0.5v-2.8
+														l2.2-1.9l-1.7-0.8l-4.7,0.8l0.3-2.2l-3.3-1.4l-0.8-6.6v-4.7l-2.8-1.9l0.3-3.9l-5.8-7.2l-0.6-5.5h-1.9l-0.8-5.5l-3.9,0.6l-0.5-3.6
+														L294.7,353.4z"></path>
+                            </a>
+                            <a class="department" id="dep-81" data-num-dep="81">
+                                <title>81 - Tarn</title>
+                                <path d="M270.8,396.9l-3.4,0.2l-2.3,2.3l-0.7-1.6l-1.6,0.9l-0.2-0.4l-0.9,0.9l-2.8,1.1l-2.3,1.4l-6,0.7l-0.7,3h2.3
+														l-2.3,2.1l-1.1,1.9h-3.3l1.8,1.9l-1,1.7l0.3,0.1l0.9,2.6l2.1,2.5l0.5,0.3l0.2,2.5l1.8,2.8l1.4,1.6v1.9l-1.4,0.5l1.1,1.6l4.6,1.9
+														l0.9,1.3l2.3,2.8l2.7,0.7l2.1-0.4v2.5l-0.1,1.3l1.2-0.2l-0.3,1.4h3.9l3.6,1.1l0.3-3.6h1.7l6.1,1.1h5.8l4.4-1.4l1.1-3.6l-3-2.8
+														l0.8-2.8l1.7-2.5l2.8,1.9l7.2-2.5l1.1-2.2l-3.7-2.3l-1.6-0.4l-1.1,1.4l-2.1,0.5l-3.4-1.8l-3.5-4.6v-1.9l-1.9-3.6l0.2-1.6l-1.6-4.1
+														l-3-1.4l-2.1-3.7l-5.8-1.1L270.8,396.9z"></path>
+                            </a>
+                            <a class="department prod" id="dep-01" data-num-dep="01" data-lien="15-NexSIS">
+                                <title>01 - Ain</title>
+                                <path d="M383.3,262.6l-2.2,0.2l-1.4,2.5l-3.7,14.4l-0.5,1.2l-0.4,4.6l-1.1,1.5v6.6l-0.6,1.5l3.8,2.3l1.5,0.2l2.3,2.1
+														l0.4,3.4l2.6-0.8l4,1.2l0.1-0.8h1.9l2.8,2.6l2.6-1.3l1.3-3.8l1.3-1.5l1.7,0.2l1.7,1.5l0.9,2.8l7.8,9.6l2.3-1.7l0.4-3.6l2.6-0.4
+														v-6.4l1.3-1.1l0.4-5.7l0.5,0.4l-0.1-2.1l-1.1-1.9l0.4-5.5l1.9,1.1l1.1-1.9l1.9-0.6l2-1.6h-2.1v-3.7l2.3-1.4l3.5-0.4l0.2-2l-1.2-0.8
+														l2.9-3.7l-0.4-1.2l-3.3-1.8l-8.1,8.9h-5.7v-2.3l-3.1-1.6l-3.7,4.1l-2.9,0.4v-2.8l-2.5-1.2l-3.9-5.5l-3.5-1.4l-1.2-2.5l-2-0.4
+														L387,264l-1.6,0.4L383.3,262.6z"></path>
+                            </a>
+                            <a class="department" id="dep-38" data-num-dep="38">
+                                <title>38 - Isère</title>
+                                <path d="M397.9,298.7l-1.3,1.5l-1.3,3.8l-2.6,1.3l-2.8-2.6h-1.9l-0.2,2.8l2.8,2.3l-4.3,5.5l-5.5,1.3l-4.3,1.5l2.8,2.8
+														l0.7,1.3l-4.3,2.1l-0.4,6.2l-0.1,0.1l1.2,2.5l3.4,1.1l2.3-0.8l2.8-1.9l3.6,3h3l2.1,3l-0.9,2.1l0.4,3l-1.1,3l0.4,1.1l1.5-0.4
+														l3.4,1.1l4.5,1.3l1.9-1.3l0.8-1.5h0.7l0.2,15.9l1.1,1.1h2.8l2.5,1.5l1.9,1.5l1.9,0.2l1.3,1.1l3.5,0.4l0.3-0.6l-1.6-0.8v-2.3h4.9
+														l1.6-1.6l-1-1.8l2.5-2l1.8,0.8l2.5-2.2l4.5,0.8l1.6-1.8l3.7,0.2v-4.3l-1.6-0.8l-0.8-2.5l-4.1-0.4l-0.6-1l0.8-4.1l1.4-1.2l-1.1-1.5
+														l-2.1-1.3l-1.3,1.3l0.4-1.7v-1.7l-1.7-1.7l0.9-4l1.9-1.1l-0.2-2.8l-4-4h-1.5l-1.1,1.5l-2.5-3.4l-1.5,0.2l-1.3,2.8l0.9,1.7l-0.7,0.7
+														l-1.7-1.3l-4.9-1.1l-2.3-4.3v-1.7l-2.3-2.5l-0.3-1.1l-7.8-9.5l-0.9-2.8l-1.7-1.5L397.9,298.7z"></path>
+                            </a>
+                            <a class="department" id="dep-74" data-num-dep="74">
+                                <title>74 - Haute-Savoie</title>
+                                <path
+                                    d="M446.1,266.2l-4.5,0.8l-4.3,3.5l-1.2-1.8l-2.2,0.2l-2,4.3l0.2,1.8l2.1,1.8l-3.9,2.6l-2.5,2.3h-4.3l-2,1.6
+														l-1.9,0.6l-1.1,1.9l-1.9-1.1l-0.4,5.5l1.1,1.9l0.1,2.1l1.6,1.3v5.5l3.8,0.6l1.5,2.8l3.4,0.4l0.6-1.3h1.7l3,3.2l1.1,1.1l3.4-0.7
+														l0.8-1.7l0.8-3.4l1.9-1.5l1.5-4.4l1.9-1.3l1.5,0.4l0.4,1.3l-1.1,1.3l1.9,2.3h3.2l1.9,3.2l-0.4,1.1l1.9-1.3l1.5-1.7l1.3,0.2l0.1-3.4
+														l6.7-2.8l0.8-1.9l-0.4-4.3l-4.3-4.5l-1.4,0.8v-1.8v-2.9l-3.7-1.8l-0.2-1.6l2.2-2.3v-2.7l-3.5-3.7l-0.2-2.5H446.1z">
+                                </path>
+                            </a>
 
-                        <div class="paragraph--lien" id="pilotes1515">
-                            <a href="/pages/accompagnement.html" class="btn btn--style1 btn--white">Ressources
-                                éditeurs</a>
-                        </div>
-                    </div>
+                            <a class="department" id="dep-42B" data-num-dep="42B">
+                                <title>42B - Loire</title>
+                                <path
+                                    d="M359.3,309.1l1.3-1.1v-1.5l-1.5-0.9l1.3-1.9v-2.8l-2.5-2.3v-2.3l-1.7-1.7V293l-0.8-3.2l1.3-1.3l0.2-3.8h4
+															l1.1-1.3l-1.3-2.1v-1.9l-1.1-0.8l-0.8,4h-2.2l-1.6,1.6l-1.2-1.2l-6.3-1l-2.3,1.4h-1.6l-0.4-1.4l-2.9-0.6l-0.2-3.1l-0.6-0.3
+															l-3.5,0.6l-0.6,2.2l1.4,2.7l0.4,11.1l-4.7,0.2l-0.2,1.8l3.1,2.5l-1.8,1.8l-0.6,4.3l2.3,3.1l2.1,5c6.1-1,14.3-2.3,21.9-3.5V309.1z">
+                                </path>
+                            </a>
 
-                    <div class="col-md-4 order-md-first">
-                        <div class="rounded-md top-left-radius-0 bg-primary text-white px-2 py-4">
-                            <div class="wysiwyg">
-                                <h3>Les pilotes</h3>
-                                <ul>
-                                    <li>SAMU 59 (Appligos), 62 (Nexpublica), 76A (RRAMU) et 80 (Exos)
-                                    </li>
-                                    <li>SAMU 77 (Scriptal) et 95 (Scriptal)
-                                    </li>
-                                    <li>SAMU 78 (Appligos) et 95 (Scriptal)
-                                    </li>
-                                    <li>SAMU 35 (Nexpublica), 44 (Nexpublica) et 50 (RRAMU)
-                                    </li>
-                                    <li>SAMU 09 (BISOM) et 11 (BISOM)
-                                    </li>
-                                </ul>
+                            <a class="department" id="dep-42A" data-num-dep="42A">
+                                <title>42A - Loire</title>
+                                <path d="M342.5,316.7l1.8,6.4l-3.7,3.5l0.6,2.3l5.5,1.8l4.3-3.5l2.1-0.2l6.3,2.7l-0.4,3.7l3.1-0.2l2.5,2.8l1.8-0.5
+															l3.4-0.6l0.9-3.8l4.7-2.8l0.4-6.2l0.2-0.1l-2.3-0.3l-2.1,0.8l-1.7-1.1l2.1-2.5l-0.6-1.9l-6.6-1.1l-5.5-5.1v-1
+															c-7.6,1.2-15.8,2.5-21.9,3.5l0,0.1L342.5,316.7z"></path>
+                            </a>
+
+                            <a class="department" id="dep-69" data-num-dep="69">
+                                <title>69- Rhône</title>
+                                <path d="M371.8,275.3l-2.1,0.2l-1.8,1.8l-1.2-1.6l-1.8,1.6l-2.4-1.6h-1.9l-0.8,0.6l-0.4,2.3l1.1,0.8v1.9l1.3,2.1
+														l-1.1,1.3h-4l-0.2,3.8l-1.3,1.3l0.8,3.2v1.9l1.7,1.7v2.3l2.5,2.3v2.8l-1.3,1.9l1.5,0.9v1.5l-1.3,1.1v1.7l5.5,5.1l6.6,1.1l0.6,1.9
+														l-2.1,2.5l1.7,1.1l2.1-0.8l2.3,0.3l4.1-2l-0.7-1.3l-2.8-2.8l4.3-1.5l5.5-1.3l4.3-5.5l-2.8-2.3l0.2-2l-4-1.2l-2.6,0.8l-0.4-3.4
+														l-2.3-2.1l-1.5-0.2l-3.8-2.3l0.6-1.5V287l1.1-1.5l0.4-4.6l-0.7,1.6l-1.4-0.2l-0.8-3.9L371.8,275.3z"></path>
+                            </a>
+                            <a class="department" id="dep-73" data-num-dep="73">
+                                <title>73 - Savoie</title>
+                                <path d="M417,293.8l-0.4,5.7l-1.3,1.1v6.4l-2.6,0.4l-0.4,3.6l-2.3,1.7l0,0l0.3,1.1l2.3,2.5v1.7l2.3,4.3l4.9,1.1
+														l1.7,1.3l0.7-0.7l-0.9-1.7l1.3-2.8l1.5-0.2l2.5,3.4l1.1-1.5h1.5l4,4l0.2,2.8l-1.9,1.1l-0.9,4l1.7,1.7v1.7l-0.4,1.7l1.3-1.3l2.1,1.3
+														l1.1,1.5l3.5-0.4l1.2,1.2l0.6,2.8l3.5-0.4l0.4-2.9l1.8-0.8l3.8,0.2l-0.1-0.1l5.8-2.3l2.2,1.4h2.2l0.2-2.3l2.5-1.4l1-1.2l5.1-2
+														l0.6-3.3l-1-1.6l2.8-4.7l-2.5-1l-0.8-2.8l-5.3-3.1c0,0,0.3-6-0.2-7.1c0,0,0-0.1-0.1-0.1c0,0,0,0,0,0c0,0,0,0,0,0c0,0,0,0,0,0
+														c0,0,0,0,0,0c0,0,0,0,0,0c0,0,0,0,0,0c-0.8,0.2-3.7,0.4-3.7,0.4l-2.9-3.3l0.1-3.2l-1.3-0.2l-1.5,1.7l-1.9,1.3l0.4-1.1l-1.9-3.2
+														h-3.2l-1.9-2.3l1.1-1.3l-0.4-1.3l-1.5-0.4l-1.9,1.3l-1.5,4.4l-1.9,1.5l-0.8,3.4l-0.8,1.7l-3.4,0.7l-1.1-1.1l-3-3.2h-1.7l-0.6,1.3
+														l-3.4-0.4l-1.5-2.8l-3.8-0.6v-5.5L417,293.8z"></path>
+                            </a>
+                            <a class="department prod" id="dep-07" data-num-dep="07" data-lien="15-NexSIS">
+                                <title>07 - Ardèche</title>
+                                <path d="M375.3,328.5l-4.5,2.7l-0.9,3.8l-3.4,0.6l-1.8,0.5l0.1,0.1l-1.2,4.7l-2.8,1.2l-1.2,2l0.8,2.5l0.6,1.4h-2.9
+														l-0.2,3.7l-3.1,0.2l-1.6,4.9h-4.7l-5.1,3.7l-2.8,4.5l0.5,0.6l1.4,7.2l3.3,3.6l-0.6,4.1l4.2,2.5v5.5l2.2-1.1l4.7,3.1l2.2,0.8
+														l0.5-3.9l2.8-0.5l0.8,3l2.8-0.3l0.5-3l6.3,3.6l1-2.1l2.7-0.4l0.2-4.1l-0.6-0.9l-0.8-0.2v-1.5l0.6-1.5l-1.1-1.7l0.6-3.8l2.6-3v-4.2
+														l-1.1-4.9l1.9-0.4l0.4-2.1l1.9-3.6l1.1-2.8l-1.7-4.3l-1.1-3.4l-1.5-5.9v-8l-1.1-0.3L375.3,328.5z"></path>
+                            </a>
+                            <a class="department" id="dep-26" data-num-dep="26">
+                                <title>26 - Drôme</title>
+                                <path
+                                    d="M384.9,329.3l-2.8,1.9l-2.3,0.8l-2.3-0.7v8l1.5,5.9l1.1,3.4l1.7,4.3l-1.1,2.8l-1.9,3.6l-0.4,2.1l-1.9,0.4
+														l1.1,4.9v4.2l-2.6,3l-0.6,3.8l1.1,1.7l-0.6,1.5v1.5l0.8,0.2l0.6,0.9l-0.2,4.1l2.6-0.4l1.2,1.4l-0.6,3.9l0.8,1l2.9-2.9l2.6-0.2
+														l0.6-1.6l-3.3-0.4l-0.6-3.5l2.1-3.3l2.8-0.2l2.7,2.6l-2.7,3.7l0.8,1.4l3.9,0.4l2.5-2.2l-1.4,2.9l0.4,2.3l4.1,0.4l5.5,0.4l0.8,2.5
+														l2.9,2.2l2.5,0.2l1.8-1.6l1-2.9l1.6,1.4l1.2,1.4l0.8-7.3l-1.9-0.4l-1.2-2.5l-6.6-1.8l-0.8-3.3l2.4-1.6l-2-1.4l0.4-1.8l3.1,0.2
+														l2.7,1.4l2.2-2.5l-2.2-1.8l0.2-2.3l1.2-3.7l4.1-0.4l3.3-1.3l0.3-0.8l-3.5-0.4l-1.3-1.1l-1.9-0.2l-1.9-1.5l-2.5-1.5h-2.8l-1.1-1.1
+														l-0.2-15.9h-0.7l-0.8,1.5l-1.9,1.3l-4.5-1.3l-3.4-1.1l-1.5,0.4l-0.4-1.1l1.1-3l-0.4-3l0.9-2.1l-2.1-3h-3L384.9,329.3z">
+                                </path>
+                            </a>
+                            <a class="department" id="dep-17" data-num-dep="17">
+                                <title>17 - Charente-Maritime</title>
+                                <path d="M149.3,270.6l-2.8,0.2l-6,3.6l1.4,1.3l-3.1,2.5l-0.4,2l-2.9,0.4l-1.6-1.8l-3.9-0.4l-0.4-2l-2.3-1.6l-3.3,1.2
+														l2.2,3.1h2.7l2.8,1.8l2.2,1.8l4.1-0.2l0.8,1.8l2.7,0.6l1,2.7l1.8,0.8l-0.2,2.2l-2.3-0.4l-0.8,1.2l1.8,2.5l-1,4.3l-2.3-0.2l0.2,2.7
+														l0.6,1h-2.8l-0.4-1.6l1.8-2.3l-0.6-1.3l-1-0.8l-0.4-4.7l-3.3-0.4l-2.7-3.3l-0.4,6.8l4.5,3.3l0.4,3.7l0.8,4.3l0.4,4.3l2.3-0.2
+														l4.1,3.3l2.8,1.6l0.2,1.9l2.2,0.4l6.3,6.3l1.5,6.8h5.8l1-1l0.2,2.9l5.1,0.6l0.8,6.3l2.8,0.2l4.5,4.5l2.3,0.4l2.8-1.4l1.9,1.4
+														l1.6-3.3l1.6-2.7l-4.2-2.8l-1.3-1.7l-1.7-1.9l-4,0.7l-1.3-0.7l-0.2-1.1l2.1-0.8v-0.4l-1.5-0.4l-1.1-0.8l2.6-2.1V324l-1.3-1.3
+														l0.8-0.8l0.4-2.1l-1.5-1.5l-1.3-2.1l-2.3-2.1l-1.7-1.1l1.5-1.7l-0.8-0.2l-0.2-4.5l-1.7-0.7l2.3-1.3h2.8l1.3-1.1h2.3l0.4,1.1
+														l2.1,0.2l1.5-0.6l0.4-4l1.7-6.2l0.1,0l-1.5-1.5l-0.4-2.1l-2.8-1.3l-3.6-2.5l-4.5,0.4l-2.8-3.6l-4-0.2l-3.2-2.3v-1.3l-2.1-2.3
+														l-0.1-2.9l-2.9-2.2l-3.7,1.6L149.3,270.6z"></path>
+                            </a>
+                            <a class="department" id="dep-19" data-num-dep="19">
+                                <title>19 - Corrèze</title>
+                                <path d="M265.8,307.6l-0.8,2.1l-3.2,0.6l-1.3,2.1H259l-2.1-0.6l-1.5,2.5l-2.3,0.2l-1.5,2.8h-1.9l-1.5,1.5l-3.8-0.4
+														l-1.3,2.1l-1.5-0.2l-2.6,3.2l-2.3-0.9l-1.1,2.2l0.8,2.2l2.2,1.8l-3.9,3.5v2.7l1.6,0.8l-1.6,2l2.2,1.8l-1.6,1.9l1.8,1.2l4.3-0.2
+														l-0.2,4.3l1.6,2.6l0.6-0.1l4.2-1.9l5,2.2l3.8,5.5l2.2-0.3l3.3-3.3l1.1,1.9l2.2-2.2l3,0.8l0.1,0.7l2.5-1.8l-0.8-1.9l-1.2-1.2
+														l1.6-1.9h1.6l1-3.1l0.8-1.6l-0.6-3.5l2.5-3.5l3.5-2.2l0.2-5.5l1.8,1l2,2.2h1.9l1.2-1.4l-1-2.3l1-3.5l-0.6-3.3l-1.2-1.4v-2.8
+														l1.8-2.9l-0.4-2.8l-0.4-0.4l-2,1.5h-3.8l-1.3,1.9H276l-1.9-1.9l-0.9-1.3h-4.9l-1.1-1.5H265.8z"></path>
+                            </a>
+                            <a class="department" id="dep-23" data-num-dep="23">
+                                <title>23 - Creuse</title>
+                                <path
+                                    d="M256.1,267.9L255,271l-3.5-0.2l-0.8-0.4l-2.3,0.2l-1.8-1.2l-3.4,3.9l0.1,2.9l-2.3,4.7l0.4,2.3l2.5,0.6l1.7,4.3
+														l1.7,1.7l-0.6,8.1l3.6-1.1l1.5,1.9l-2.3,1.9v1.9l1.9,0.2l3.4-0.2l1.1-1.5h0.8l-0.4,2.6l2.8,1.3l2.6,1.7v1.1H260l0.4,2.5l1,0.6
+														l0.3-0.4l3.2-0.6l0.8-2.1h1.5l1.1,1.5h4.9l0.9,1.3l1.9,1.9h2.3l1.3-1.9h3.8l2-1.5l-4.1-4.1l-0.4-1.8l3.7-2.2l2.2-1.2l0.6-2.8
+														l2.3-1.8l-0.8-3.7l-1.6-1.9l-0.4-6.1l-2.2-5.1l-2.2-0.8l-1.6-2.8l-1.4,1.8l-1.3-1.8v-2.3l-2.3-3.3l-6.4,0.8l-3.7-1L256.1,267.9z">
+                                </path>
+                            </a>
+                            <a class="department" id="dep-87" data-num-dep="87">
+                                <title>87 - Haute-Vienne</title>
+                                <path d="M239.5,270.8l-1.8,1.8l-4.9-0.4l-0.6-0.1l-3.7,0.7l-2.2,1.8v2.3l-4.3,0.2l-2.5,2.9l-1.6,1.2l1.3,1.6l-0.2,5.3
+														l-1,1.8l1.6,1.8l2.7,0.2l0.6,2.7l0.2,1.8l-3.5,0.8l-1.8,0.6l0.4,4.9l-2.3,1.6l-2,0.6l-1,2.8l-1.6,0.2l-0.7,3l4.6,0.2l1,1.9
+														l-0.8,2.2l1.8,2.3l1.3-0.4l1.4-2l6.3,0.6l1,3.9l4.3,0.6l1,1.3l-2.9,1.4l1.4,1l4.1,0.6l0.3,0.8l1.1-2.2l2.3,0.9l2.6-3.2l1.5,0.2
+														l1.3-2.1l3.8,0.4l1.5-1.5h1.9l1.5-2.8l2.3-0.2l1.5-2.5l2.1,0.6h1.5l1-1.7l-1-0.6l-0.4-2.5h1.5v-1.1l-2.6-1.7l-2.8-1.3l0.4-2.6h-0.8
+														l-1.1,1.5l-3.4,0.2l-1.9-0.2v-1.9l2.3-1.9l-1.5-1.9l-3.6,1.1l0.6-8.1l-1.7-1.7l-1.7-4.3l-2.5-0.6l-0.4-2.3l2.3-4.7l-0.1-2.9
+														l-0.5,0.6L239.5,270.8z"></path>
+                            </a>
+                            <a class="department" id="dep-86" data-num-dep="86">
+                                <title>86 - Vienne</title>
+                                <path d="M188.8,225.7l-3.7,3.9l-0.9,1.6l0.3,4.8l1.7-0.2l0.2,2.1l0.7,3.4l1.1,2.3l-1.3,1.5l0.6,1.1l-0.8,1.5v0.6
+														l1.5,1.7v1.1l-0.7,1.7l-2.1,3.2l2.1,0.8l0.7,1.5l-0.9,2.3l-0.2,1.1l-1.3,2.1v1.5l0.8,0.2v4.5l1.5,1.1l-0.7,1.5l0.2,1.3l1.7,1.9
+														l0.9-1.3v-1.1l1.7-0.8l1.3,0.8v3.2l-1.3,1.5l-1.1,2.5l1.5,2.3l3,0.8l-0.7,1.9l-2.8,0.5l2.6,3.1l3.4-0.2l3-1.1l3,1.7l1.1-0.8
+														l-0.2-2.8l1.7-1.3l1.5,2.6l1.3,1.3l3.6-1.5l1.5-1.7h3.4l1.8,0.9l0.1-3.7l-1.3-1.6l1.6-1.2l2.5-2.9l4.3-0.2v-2.3l2.2-1.8l5.3-1
+														l0.4-2.9l-2.1-1.2l-1.2-4.1l-3.1-0.4l-1.9-1.9l-3.7-2.9l0.8-2.3v-3.7l-3.5-3.5L219,246l-3.3-3.5l-1.2-4.7l-1.4-0.6l-1.6-2.2l-1.6,1
+														l0.4,2.2l-5.1,1.2h-5.8l0.2-2.3v-3.7l-4.7-1.4v-2.3l-3.7-0.8l-0.8-3.1H188.8z"></path>
+                            </a>
+                            <a class="department" id="dep-16" data-num-dep="16">
+                                <title>16 - Charente</title>
+                                <path d="M206.3,284.9l-1.7,1.3l0.2,2.8l-1.1,0.8l-3-1.7l-3,1.1l-3.4,0.2l-2.6-3.1l-0.8,0.2l-3.4,1.7l-2.6,0.7v1.5
+														l-1.5,1.7l0.4,1.1l-1.9,1.1l-1.7,6.2l-0.4,4l-1.5,0.6l-2.1-0.2l-0.4-1.1h-2.3l-1.3,1.1h-2.8l-2.3,1.3l1.7,0.7l0.2,4.5l0.8,0.2
+														l-1.5,1.7l1.7,1.1l2.3,2.1l1.3,2.1l1.5,1.5l-0.4,2.1l-0.8,0.8l1.3,1.3v1.5l-2.6,2.1l1.1,0.8l1.5,0.4v0.4l-2.1,0.8l0.2,1.1l1.3,0.7
+														l4-0.7l1.7,1.9l1.3,1.7l4.2,2.8l0.6-1l3.9,0.4l1.9-1.8l3.5-3.5l0.2-6.8l9.2-6.3l0.2-4.7l2.8-0.4l1.8-3.1l1.1,0l0.7-3l1.6-0.2l1-2.8
+														l2-0.6l2.3-1.6l-0.4-4.9l1.8-0.6l3.5-0.8l-0.2-1.8l-0.6-2.7l-2.7-0.2l-1.6-1.8l1-1.8l0.1-1.6l-1.8-0.9h-3.4l-1.5,1.7l-3.6,1.5
+														l-1.3-1.3L206.3,284.9z"></path>
+                            </a>
+                            <a class="department" id="dep-79" data-num-dep="79">
+                                <title>79 - Deux-Sèvres</title>
+                                <path d="M181.7,229.4l-5.3,0.2l-4.9,1l-5.3,0.4v2.7l-2.7,1.8l-6.1-1.4l-4.1,1.8l1.9,2.8v2.3l4.7,3.9l-1.2,2.5l3.1,3.5
+														l-1.4,1.8l1.9,2.9l0.6,5.5l-1.2,1.6l1.4,2.3l-1.4,2.6l0.2,1.6l1.6-1.2l1.9,2l-2.7,1.8l-1,1.2l-2.2,0.6l-2.5,1.2l-0.2-0.2l0.1,2.9
+														l2.1,2.3v1.3l3.2,2.3l4,0.2l2.8,3.6l4.5-0.4l3.6,2.5l2.8,1.3l0.4,2.1l1.5,1.5l1.8-1l-0.4-1.1l1.5-1.7v-1.5l2.6-0.7l3.4-1.7l3.6-0.6
+														l0.7-1.9l-3-0.8l-1.5-2.3l1.1-2.5l1.3-1.5v-3.2l-1.3-0.8l-1.7,0.8v1.1l-0.9,1.3l-1.7-1.9l-0.2-1.3l0.7-1.5l-1.5-1.1v-4.5l-0.8-0.2
+														v-1.5l1.3-2.1l0.2-1.1l0.9-2.3l-0.7-1.5l-2.1-0.8l2.1-3.2l0.7-1.7v-1.1l-1.5-1.7v-0.6l0.8-1.5l-0.6-1.1l1.3-1.5l-1.1-2.3l-0.7-3.4
+														l-0.2-2.1l-1.7,0.2l-0.3-4.8l-0.4,0.7l-1.4-1.2L181.7,229.4z"></path>
+                            </a>
+                            <a class="department" id="dep-22" data-num-dep="22">
+                                <title>22 - Côtes-d'Armor</title>
+                                <path d="M69.8,123.2l-1.8,1.4l-4.5,0.6l-1,1.4l-3.1-2.3l-4.1,2.8l1.6,2.1l-2.7,3.7l-0.1-0.1l-1.1,5.3l2.4,0.2l-0.2,2.1
+														l1.8,1.1l-1.6,1.6l-1.1,0.8l0.2,1.9l2.4,0.8l-2.3,0.7v2.4l1.5,1.9l0.3,5.7l-1,1l0.8,2.9l3.1,0.8l0.3,1.6l1.9,0.2l1.6-1.1l1,1
+														l3.7,1.6l3.1-1.6l0.8-1.6l2.6-0.2l2.9,2.6l2.8-0.7l2.4,2.4h1.1l1.1,1.4h2.3l0.8-1.1l1,2.1l2.4,1l3.1-1.9v-2.1l2.3-0.8h1.4l1.8,3.3
+														l3.9,0.3l1.9-2.4l2.1-4.5l2.8-1l1.4-2.1l1.5,1.4l3.1-0.6l1-8.9l1-3.6l-1-1.9l-1.6-0.6l-1.1-5.9l-1.3,1.4l-3.7-0.4l-0.4,2.2
+														l-2.3,0.2l-0.2-2.7l-2-0.6l-1.4,1.6v-3.9l-2.3,1.8l-3.5-0.6l-1.2,2.3l-7.2,3.9v2h-1.6v-3.5l-4.1-1.9l0.4-3.5l-3.7-2.7v-3.3
+														l-2.8-0.6l0.2-3.1l-2.1-0.2l0.2-2.2h-3.9l-0.6,1.9L69.8,123.2z"></path>
+                            </a>
+                            <a class="department" id="dep-85" data-num-dep="85">
+                                <title>85 - Vendée</title>
+                                <path d="M138.5,229.6l-1.1,2.1h-3.2l1.3,1.3l-1,3.2l-2.9,1l-1.1-0.8l0.5-3.2l-0.8-1.8h-1.8l-1.3,1.4l0.6,4.5l1.5,2.1
+														l-1.5,1.6l-2.7-0.5l-4-1l-1.1-3.1l-2.6-0.3l-3.4-1.5l-0.8-1.9l-3.7-2.4l-5.8,7.5l-0.2,4.7l6,5.8l-0.2,1.8h1.8l3.7,11.2l3.9,1.9
+														l3.9,3.9h4.5l1.8,3.9h4.3l1.9,2.9l4.3,2.2l0.2-2.8l1.1,1l6-3.6l2.8-0.2l1.2,3.1l3.7-1.6l3.1,2.3l2.5-1.2l2.2-0.6l1-1.2l2.7-1.8
+														l-1.9-2l-1.6,1.2l-0.2-1.6l1.4-2.6l-1.4-2.3l1.2-1.6l-0.6-5.5l-1.9-2.9l1.4-1.8l-3.1-3.5l1.2-2.5l-4.7-3.9v-2.3l-1.9-2.8l0.4-0.2
+														l-2.7-2.3h-5l-1.6-1l-2.3-0.3l-2.6-2.4L138.5,229.6z"></path>
+                            </a>
+                            <a class="department" id="dep-50" data-num-dep="50">
+                                <title>50 - Manche</title>
+                                <path d="M119.6,77.5l-0.8,2l4.1,3.3v4.3l-1.6,1.9l1,1l0.6,0.4l-0.4,3.7l1.4,3.1l4.5,5.1l1,4.5l1,1.4v7l2.3,4.7v5.5
+														l-2.5,5.1l2.7,7l4.3,1l0.4,2l-2.1,1h-3.7l0.6,2.5l1.2,3.7l3.3,2.9l1.6,0.4l1.6-2.1l1.8-0.2l2.1-2.5l2,1.6h2.3l1.6,0.8v0.4l3.3,0.4
+														l2-1.6l2.9,1.2l0.1,0.1l3.3-2.8l1.1-3.7l-0.3-1.6l0.5-1.9l-1.9-1.9l-5-3.3l-3.7-0.3l-3.7-4.7l3.1-1.1l1.3-2.4l-1.6-1.5l1.4-1.3
+														l1.4,1.1l2.6-1.6l1.6-2.6l0.6-2.6l-1.1-2.3l0.7-0.8l-1.5-2.4l1.6-2.1l-1.3-1.6l-1.6,2.1l-2.3-1.3l-3.7-3.7l-0.2-1.6l1.1-1.1
+														l-0.3-2.2l-1.8,0.5l-0.2-4.7l-5.1-6l1.6-3.9h2.2l-1.9-5.3l-8.4-0.4l-4.5,3.1l-5.1-3.3L119.6,77.5z"></path>
+                            </a>
+                            <a class="department" id="dep-56" data-num-dep="56">
+                                <title>56 - Morbihan</title>
+                                <path d="M56,160.6l-3.3,1.6h-2.3l-2.4,1.9l0.2,1.4l1.4,3.7l0.8,2.9l5,0.8l2.4,1.9l1-1.2l1.6,2.1l-0.8,1l-0.2,2.9h-1.4
+														l-1.1,1.8h-2.3l-0.9,3.8l2.2,3.5l3.1,0.8l1.2-1.8l-0.6,2.1l2.7,1.2l3.5,3.5l1.2,2.2l-0.4,2.5l-0.4,2.6l2.3,1.8l1.2-1.4l-1.2-1.6
+														v-3.5l2.3,0.6l0.8-2.3l0.6,1.4l2.5,2.2l1.2-2l-1.2-2.7l2.2,2.9l2.7-0.4l-0.6-1.4l2.5,0.6l1.9,2.3l-1,1.6l-2.5-0.8l-2.9-1.4l-1.6,2
+														l2.3,0.8l1.8,2.7l10.6-1l2.7,0.6l-1.3,1.2l0.2,1.8l0.4,0.3l0.8-0.2l1.8-1.8l1.2,1.3h3.1l3.7-1.9l5.5-2.2l0.2-5.5l1.2-0.6l-2.1-3.9
+														l1.8-1.4l-0.3-1l-1.1-0.7l1.8-0.8l1.6-1.9l-0.2-1.9H109l-0.5-1.9l1.5-1.9l-1.6-2.9l-2.4-1.5h-2.8l-1-0.3v-1.3l1.4-1.3l0.8-3.2
+														l-0.5-2.1l-0.7,0.8l-3.9-0.3l-1.8-3.3h-1.4l-2.3,0.8v2.1l-3.1,1.9l-2.4-1l-1-2.1l-0.8,1.1h-2.3l-1.1-1.4h-1.1l-2.4-2.4l-2.8,0.7
+														l-2.9-2.6l-2.6,0.2l-0.8,1.6l-3.1,1.6l-3.7-1.6l-1-1l-1.6,1.1l-1.9-0.2l-0.3-1.6l-3.1-0.8L56,160.6z"></path>
+                            </a>
+                            <a class="department" id="dep-29" data-num-dep="29">
+                                <title>29 - Finistère</title>
+                                <path d="M40.7,129.1l-2.1,2.3l-2.3-1l-4.3,0.4l-0.8,1.9l-2.5,0.6l-0.4-2.2l-4.5,0.6v1.4l-3.1,0.2l-1.4-1l-1.6,0.8
+														l-0.4,2.3l-5.3,0.2L9.2,139l2.3,1.8l-3.1,2.6l1,1.8l-0.8,4.3l3.1,0.4l1.2-1.2l0.6,0.8l7.4-1l4.9-3.5l-4.3,4.1l0.4,1.9l3.9-1.8
+														l-0.8,2.8l4.3,0.2l-0.2,1.2l-4.7-0.2l-3.7-1l-4.5-2.2l-2.7,3.1l3.5,1.2l-0.2,5.3l1-0.8l2.2-3.3l4.1,2.3l2,0.4l0.8,3.1l-1.2,2.1
+														l-2.5-0.2h-2.3l-3.9,0.6l-6.7,0.4L8.8,166l1.9,1.2l2.2-0.2l1.8,1.6l2.5-0.2l4.1,4.7l1,5.1l-1.4,2.8l4.1,0.8l4.5-0.2l1-1.8l-1.8-2.3
+														l1.8,0.8l1.8-0.2l3.1,1.8l1.9-0.4v-3.3l0.8,3.3l2.5,4.1l5.5,0.4l0.2-1.2l1.3,1.9l3.3,0.6h2.5l0.2,0.2l0.9-3.8h2.3l1.1-1.8h1.4
+														l0.2-2.9l0.8-1l-1.6-2.1l-1,1.2l-2.4-1.9l-5-0.8l-0.8-2.9l-1.4-3.7l-0.2-1.4l2.4-1.9h2.3l3.3-1.6l-0.7-2.5l1-1l-0.3-5.7l-1.5-1.9
+														v-2.4l2.3-0.7l-2.4-0.8l-0.2-1.9l1.1-0.8l1.6-1.6l-1.8-1.1l0.2-2.1l-2.4-0.2l1.1-5.3l-3.2-1.9l-5.5,0.2v3.9h-1.6l-0.4-1.8l-2.3,0.4
+														L40.7,129.1z"></path>
+                            </a>
+                            <a class="department" id="dep-35" data-num-dep="35">
+                                <title>35 - Ille-et-Vilaine</title>
+                                <path d="M116.3,135.9l-1.9,2.1l1.1,5.9l1.6,0.6l1,1.9l-1,3.6l-1,8.9l-3.1,0.6l-1.5-1.4l-1.4,2.1l-2.8,1l-2.1,4.5
+														l-1.3,1.6l0.5,2.1l-0.8,3.2l-1.4,1.3v1.3l1,0.3h2.8l2.4,1.5l1.6,2.9l-1.5,1.9l0.5,1.9h2.1l0.2,1.9l-1.6,1.9l-1.8,0.8l1.1,0.7l0.3,1
+														l-1.8,1.4l2.1,3.9l3.9-2.1l12.1-0.6l0.8-2.2l2-1.9l4.3-0.6l0.2-2.2l2.9,0.4l1.8,2.3l3.9,1l0.8-1.6l1-3.5l2.5-6.3l1.4-0.8l3.3,0.4
+														v-5.3l-1.4-1.4v-5.7l-0.6-1.9v-3.1l2-2v-3.9l-1-0.8l0.2-5.5l-1.6-0.8h-2.3l-2-1.6l-2.1,2.5l-1.8,0.2l-1.6,2.1l-1.6-0.4l-3.3-2.9
+														l-1.2-3.7l-0.6-2.5h-9.6l-3.5-2.2l2.3-3.1L116.3,135.9z"></path>
+                            </a>
+                            <a class="department prod" id="dep-44" data-num-dep="44" data-lien="15-NexSIS">
+                                <title>44 - Loire-Atlantique</title>
+                                <path
+                                    d="M132.9,185.8l-0.2,2.2l-4.3,0.6l-2,1.9l-0.8,2.2l-12.1,0.6l-5.1,2.7l-0.2,5.5l-5.5,2.2l-3.7,1.9H96l-1.2-1.3
+														l-1.8,1.8l-0.8,0.2l1,0.7l-3.7,3.3l0.8,0.8l0.8,1.6l-2,2.8l2.2,1.2l3.7,0.8l0.4-1.6l2.2,2.8h3.5l2.5-2.8h3.3l-3.5,1.8l0.2,2
+														l0.8,1.8l-2.2,2.2h-2.3l0.4,2.9l4.3-0.8l5.1,4.7l-0.3,0.3l3.7,2.4l0.8,1.9l3.4,1.5l2.6,0.3l1.1,3.1l4,1l2.7,0.5l1.5-1.6l-1.5-2.1
+														l-0.6-4.5l1.3-1.4h1.8l0.8,1.8l-0.5,3.2l1.1,0.8l2.9-1l1-3.2l-1.3-1.3h3.2l1.1-2.1l1.1,0.2l2.6,2.4l1.9,0.3l0.1-2l-1.6-2.1h-1.4
+														l-0.5,0.2l-1-0.5l0.8-0.8v-1.5l1.6-0.5l1-2.3l-0.8-0.8l-0.2-2.8H140l-2.1-2.6v-1.9l2.3-1.2l4-0.8l6.3,0.2l1.9-1.3l-0.7-4l-2.9-2.7
+														l-3.5,0.5l-1-0.8l-0.2-2.9l2.6-2.3l-1.9-2.4l-1.3-3.4l-2.1-1.3v-2.3l-0.2-0.7l-3.7-0.9l-1.8-2.3L132.9,185.8z">
+                                </path>
+                            </a>
+                            <a class="department" id="dep-49" data-num-dep="49">
+                                <title>49 - Maine-et-Loire</title>
+                                <path d="M141.9,188.7l-0.4,0.9l-0.3-0.1l0.2,0.7v2.3l2.1,1.3l1.3,3.4l1.9,2.4l-2.6,2.3l0.2,2.9l1,0.8l3.5-0.5l2.9,2.7
+														l0.7,4l-1.9,1.3l-6.3-0.2l-4,0.8l-2.3,1.2v1.9l2.1,2.6h2.1l0.2,2.8l0.8,0.8l-1,2.3l-1.6,0.5v1.5l-0.8,0.8l1,0.5l0.5-0.2h1.4
+														l1.6,2.1l-0.1,2l0.4,0.1l1.6,1h5l2.7,2.3l3.7-1.6l6.1,1.4l2.7-1.8V231l5.3-0.4l4.9-1l5.3-0.2l0.6,1.4l1.4,1.2l1.3-2.3l3.7-3.9h1.5
+														l2.2-8l3.1-3.7l-0.2-4.3l2-2.6V206l-1-1.2l0.6-1.3l-2.7-1l-8.2-5l-7.6-2.3l-2.9-0.2v-1.9l-1.8-1.5h-1.9l-3.6-1.1l-2.3,2.3L161,193
+														l-2.3-1.3l-5.8-1.8l-1.3,1.6l-3.2-2.1h-2.9L141.9,188.7z"></path>
+                            </a>
+                            <a class="department" id="dep-72" data-num-dep="72">
+                                <title>72 - Sarthe</title>
+                                <path
+                                    d="M202.4,151.9l-5.3,0.2l-5.3,4.9l-2.8-0.2l-3.7,1.2l-1.1,1.9l-0.5,4.2l0.3,2.6l-2.9,2.4l-0.8,1.6l0.7,1.5
+														l-0.8,1.9l0.3,0.8l-3.2,0.3l-0.5,1.4l1.4,3.6l-0.2,1l-1.3,1.1l-2.8,0.2l-0.3,1l0.7,1v5.8l-0.6,1.5l1.8,1.4v1.9l2.9,0.2l7.6,2.3
+														l8.2,5l2.7,1l1.3-2.6l3.9,2.8h2.2l-1.2-3.9l2.4,1.6l1.3-2l5.7-1.6l-1-2.3l1.4-1.8l2.9-1.2l2.7-3.5v-3.7h2l0.8-2.7l0.2-4.1l-1.9-1.8
+														l1.6-2.7l2.3-2.9l-2.7-1.9l-2.5-0.4l-2.8-4.1h-0.8l-0.2,1.9l-0.2-1.3h-4.1l-2-2.9L205,161l-1-7L202.4,151.9z">
+                                </path>
+                            </a>
+                            <a class="department" id="dep-53" data-num-dep="53">
+                                <title>53 - Mayenne</title>
+                                <path d="M182.5,146.4l-1.9,0.2l-0.8,1.9l-2.9,1.2l-5.3-0.8l-5.3,3.1l-1.9-1.4l-2.9,2l-2.2-1.6l-1.4-2.3l-2.9-1.2
+														l-2,1.6l-3.3-0.4l-0.2,5.1l1,0.8v3.9l-2,2v3.1l0.6,1.9v5.7l1.4,1.4v5.3l-3.3-0.4l-1.4,0.8l-2.5,6.3l-1,3.5l-0.3,0.7l3.5,0.7h2.9
+														l3.2,2.1l1.3-1.6l5.8,1.8l2.3,1.3l5.2-0.2l2.3-2.3l3.6,1.1h1.9l0,0l0.6-1.5v-5.8l-0.7-1l0.3-1l2.8-0.2l1.3-1.1l0.2-1l-1.4-3.6
+														l0.5-1.4l3.2-0.3l-0.3-0.8l0.8-1.9l-0.7-1.5l0.8-1.6l2.9-2.4l-0.3-2.6l0.5-4.2l1.1-1.9l3.7-1.2l-0.6,0l-1-3.5l-2.5-1l-0.8-4.3
+														L182.5,146.4z"></path>
+                            </a>
+                            <a class="department" id="dep-14" data-num-dep="14">
+                                <title>14 - Calvados</title>
+                                <path d="M202.7,97.8l-4.6,0.8l-7.4,4.3l-8.4,3.3l-6.7-3.7l-16-2.3l-3.7-1.9l-5.8,1.5l0.3,2.2l-1.1,1.1l0.2,1.6l3.7,3.7
+														l2.3,1.3l1.6-2.1l1.3,1.6l-1.6,2.1l1.5,2.4l-0.7,0.8l1.1,2.3l-0.6,2.6l-1.6,2.6l-2.6,1.6l-1.4-1.1l-1.4,1.3l1.6,1.5l-1.3,2.4
+														l-3.1,1.1l3.7,4.7l3.7,0.3l2.8,1.8l3.9-1.2l2.9-3.4l4,1.1l3.5-2.4l2.1-0.8l2.3,2.3l3.7-0.7l3.2,1.8l4-1.3l3.7-2.8l2.4-2.8l1.6-0.3
+														l0.5,2.1l1.3-0.3l0.2-1.5l3.7-0.6l1.3,0.8l4-0.9l0.7-1.9l-0.2-1.8l-2-0.8l-0.2-1.4l1.8-1.2l0.2-2l-1.2-4.7l-2.3-3.3l2-1.2v-0.8
+														l-2-0.6L202.7,97.8z"></path>
+                            </a>
+                            <a class="department" id="dep-61" data-num-dep="61">
+                                <title>61 - Orne</title>
+                                <path d="M206.8,124.7l-4,0.9l-1.3-0.8l-3.7,0.6l-0.2,1.5l-1.3,0.3l-0.5-2.1l-1.6,0.3l-2.4,2.8l-3.7,2.8l-4,1.3
+														l-3.2-1.8l-3.7,0.7l-2.3-2.3l-2.1,0.8l-3.5,2.4l-4-1.1l-2.9,3.4l-3.9,1.2l2.2,1.4l1.9,1.9l-0.5,1.9l0.3,1.6l-1.1,3.7l-3.3,2.8
+														l1.3,2.2l2.2,1.6l2.9-2l1.9,1.4l5.3-3.1l5.3,0.8l2.9-1.2l0.8-1.9l1.9-0.2l1.8,1.6l0.8,4.3l2.5,1l1,3.5l3.3,0.2l5.3-4.9l5.3-0.2
+														l1.6,2.1l1,7l3.3,1.2l2,2.9h4.1l0.2,1.3l0.2-1.9h0.8l2.8,4.1l2.1,0.3v-4.6l-1.3-1.8l-0.4-1.6l2.9-1.8l2.9-0.6l1.9-2.3l-0.4-7.2
+														l-4.1-3.5l-0.2-3.3l-3.5-2.3l1.4-1.9l-0.8-2.9l-2.7-1l-2-2l-1.2-2.7l-5.5-0.2l-1.6-2L206.8,124.7z"></path>
+                            </a>
+                            <a class="department" id="dep-28" data-num-dep="28">
+                                <title>28 - Eure-et-Loir</title>
+                                <path
+                                    d="M247.2,126.1l-1.2,1v3.1l-3.9,1.9v2.9l-1.2,1.4H236l-2.3-1l-7.1,3.7h-2.7l-2.8,2.7l0.7,0.4l0.2,3.3l4.1,3.5
+														l0.4,7.2l-1.9,2.3l-2.9,0.6l-2.9,1.8l0.4,1.6l1.3,1.8v4.6l0.4,0.1l2.7,1.9l-1,1.3l1.9,1l3.1-0.6h1.8l-0.1,0.8l-1.7,1l1.1,0.8h2.8
+														l1,2.3l1.7,1l1.3,2.8l4.3,1.1l2.7-0.3l2.4-2.3l2.1,0.6l0.5-1.2l-0.1-1.3l1.1-0.8l1.8,1.1l1.1-0.8V176l1.5-1l1.4,0.6l1.3,1.4
+														l2.3-1.3h2.4l1.7-1.8l1-3.6l1.5-0.3l-0.4-3.7l1.8-1.5l-0.6-1.1l0.2-0.4l-0.5,0.1l-0.4-5.3l-0.4-0.6l-0.4-2.5l-4.1-0.8l-1.8-2.2
+														l-0.6-4.3l-2.3-0.4l-0.4-2.2l-2.7-1.9l-1.4-3.3l1.4-2.3l-1.4-1.6v-1.9l0.8-2.2l-1.6-1.6l-0.6-2.3L247.2,126.1z">
+                                </path>
+                            </a>
+                            <a class="department" id="dep-89" data-num-dep="89">
+                                <title>89 - Yonne</title>
+                                <path d="M318.4,157.3l-1.8,1.3l-7.6-0.4l-3.5,1.8l-1.4,2.9l1.6,1.8l-2.3,2.8l-1.8,2.1l3.5,3.3l1,3.1l2.6,2.7v3.5
+														l-5.1,4.3l1.8,2l-0.4,2.9l-2.8,2h-3.9l0.6,2.2l2.5,3.5l0.6,3.1l0.6,2.2l-1.2,0.3l2.5,0.6h1.8l1-1.5h1.3l1.4,1.3l-0.3,1.6l1.3,0.8
+														h1.8l2.5,1.7l1.1-0.6l1.1,1l1.1-0.3l1.9-1.3l1.8,0.6l1.3-0.3v-3.5l0.7,0.1l0.4,1.8l2.3,1.4v2.1l3.2,0.1l4.2,3.9l2.7,0.1l-0.2-1.3
+														l1.1-1.7l1,1.3l-0.8,1.4l0.4,1.3l1.5-1h1.8l-0.2,2.8l1.7,1.1l1.3-0.6l3.1-2.1l-0.2-0.4l-1.8-1.1l-0.1-2l2-1l0.8-1.1l-0.6-1v-2.3
+														l1.5-2.3l2.3-4.8l0.4-2.1l1.4-0.6l0.2-0.4l-0.7-0.6v-1.7l2.3-1.7l0.6-2.8l-1-1.7h-1.6l-0.4-0.4v-2.4l2-1.4l-0.2-1.4l-0.3-1.4
+														l-1,2.2l-1.4-0.2l-1.2-2.2l-3.9,2l-7.8-0.4l-1-2.2l-2.2-2.9l-0.4-3.5l-3.1-3.7l-2,1.4l-3.5-2.7l0.6-5.3l-5.1-5.3h-2.3L318.4,157.3z
+														"></path>
+                            </a>
+                            <a class="department" id="dep-70" data-num-dep="70">
+                                <title>70 - Haute-Saône</title>
+                                <path d="M423.5,175.5l-3.7,0.6l-0.6,1.9l-2,1.4l-1.3-1.6l-1,0.6l0.8,1.2l-1.9,1.2l0.6,1.6l-2.2,0.8v2.5h-2.8l-0.2,1.6
+														l-2.7,0.6l0.2,2.3l1.8,0.2l-1,1.2l-0.6,3.9h-1.8l-2.9,1.2l-3.1-1.2l-2.7,1.2v2l2.1,0.4l1.6,3.1l0.2,1.6l-2.5,2.9l-1.2,0.4l-0.8,1
+														l2.2,1l0.4,3.1l1.8,0.2l0.2,3.9l0.8,0.8l0.1,0.6l1.5,0.4l1.7,1.4h2.5l1-1l1.7,0.1l1.8,0.1l3.9-3.2h1.1l1.3-1l4.1,0.1l3.1-2.5
+														l2.3-0.4l0.8-2.1l1.8-0.6l1.8-3.1l2.5-2l2.7-0.4l2,1.4l3.7-0.4v-2l1.5-0.8l1.2-1.6h2.3l1.3-1.3l0.5-3.1v-1.9l-0.8-3v-2.5l1.5-1.1
+														l1.8-0.9l-0.2-0.4l-6.3-3.3l-1.8-2l-1.8-1.2l-1.6,0.8l-0.2,1.2l-1.6,1h-1l-2.9-3.3h-4.1l-1.8,1.4l-1.6,0.2l-2.5-1.9l0.2-2.2
+														L423.5,175.5z"></path>
+                            </a>
+
+                            <a class="department" id="dep-76B" data-num-dep="76B">
+                                <title>76B - Seine-Maritime</title>
+                                <polygon
+                                    points="217.4,73.2 207.6,76.7 199.6,81 194.9,88 193.9,93.5 197.8,96.4 203.5,97.6 202.6,97.8 202.6,98
+															207,97.4 209.3,95 211,94.6 212.9,98 215.6,97.7 216.7,99.6 221.5,99.3 226.3,102.7 223.2,103.7 225.5,105.4 226.9,105.4
+															228.2,108.1 230.5,108.1 231.2,106.4 229.5,105.3 234.3,103.9 239.3,103.3 240.6,99.6 241.8,98.6 226.7,70.9 		">
+                                </polygon>
+                            </a>
+
+                            <a class="department" id="dep-76A" data-num-dep="76A">
+                                <title>76A - Seine-Maritime</title>
+                                <polygon points="256.5,94.9 256.5,91.6 255.3,89.7 256.1,85.8 256.9,83.8 255.3,83.8 256.1,81.9 258,79.6 256.1,76.1
+															255.5,72.6 246.9,64.2 245.9,62.3 243.7,62.5 241.9,61.5 240.6,63.1 232.2,69.5 226.7,70.9 241.8,98.6 243,97.5 247.5,97.4
+															252.7,100.1 255.8,100.4 256.3,98.8 257.7,96.2 258.5,94.9 		"></polygon>
+                            </a>
+
+                            <a class="department" id="dep-27" data-num-dep="27">
+                                <title>27 - Eure</title>
+                                <path d="M211,94.6l-1.7,0.4l-2.3,2.4l-4.4,0.6l0.9,7.3l2,0.6v0.8l-2,1.2l2.3,3.3l1.2,4.7l-0.2,2l-1.8,1.2l0.2,1.4
+														l2,0.8l0.2,1.8l-1.6,4.5l1.6,2l5.5,0.2l1.2,2.7l2,2l2.7,1l0.8,2.9l-1.4,1.9l2.8,1.9l2.8-2.7h2.7l7.1-3.7l2.3,1h4.9l1.2-1.4v-2.9
+														l3.9-1.9v-3.1l1.1-0.9l-0.1-0.9l1-1l-1.8-0.4v-1.6l-1-1.6l0.8-1l5.5-1.6l1.4-2.3l1.2-4.3l1.4-1.8l0.3-2.3l1.8,1l1.4-0.4l-1-1.6
+														l-0.6-4.5l-1.8-1.6l0-0.1l-3.1-0.3l-5.2-2.7l-4.5,0.1l-2.4,2.1l-1.3,3.7l-5,0.6l-4.8,1.4l1.7,1.1l-0.7,1.7h-2.3l-1.3-2.7h-1.4
+														l-2.3-1.7l3.1-1l-4.8-3.4l-4.8,0.3l-1.1-1.9l-2.7,0.3L211,94.6z"></path>
+                            </a>
+                            <a class="department" id="dep-37" data-num-dep="37">
+                                <title>37 - Indre-et-Loire</title>
+                                <path d="M212.2,196.9l0.4,0.9l-5.7,1.6l-1.3,2l-2.4-1.6l1.2,3.9h-2.2l-3.9-2.8l-1.9,3.9l1,1.2v1.2l-2,2.6l0.2,4.3
+														l-3.1,3.7l-2.2,8h0.3l0.8,3.1l3.7,0.8v2.3l4.7,1.4v3.7l-0.2,2.3h5.8l5.1-1.2L210,236l1.6-1l1.6,2.2l1.4,0.6l1.2,4.7l3.3,3.5
+														l0.4,2.8l3,3l1.7-0.2l2.1-2l1.5-8l1-2.8l0.7-3.5l3.1-1.1l2.1,0.4l1.4,1.3l1.5-2.5l1.4-1.3v-1.5l1.8-0.1l0.4-1.8l-1.6-2.1l0.3-0.9
+														l-1.1-0.9l-2.9-4.3h-3.8l-1.1-1.7v-7l-1.5-4.1l-0.3-5l-2-0.2l-2.3-1.7h-0.6l-2,1.4l-1.3-0.8l-0.3-1.9l1.4-0.7l0.1-0.7l-0.8-0.7
+														L212.2,196.9z"></path>
+                            </a>
+                            <a class="department" id="dep-45" data-num-dep="45">
+                                <title>45 - Loiret</title>
+                                <path
+                                    d="M273.7,160.5l-2.5,2.3l-5.7,0.5l-0.2,0.4l0.6,1.1l-1.8,1.5l0.4,3.7l-1.5,0.3l-1,3.6l-1.7,1.8h-2.4l-2.3,1.3
+														l-1.3-1.4l-1.4-0.6l-1.5,1v1.5l-1.1,0.8l-1.8-1.1l-1.1,0.8l0.1,1.3l-0.5,1.2l0.4,0.1h1.7l-0.1,1.1l-1.1,1.9v1h1.1l1,1.1l0.3,1.1
+														l-2.2,2.2l1.1,2.7v1.3l1.8,1.3l2.5,0.3l1.7,1.4l0.4,2.4l1.8,2.1l2-0.6l0.8-1.8l3.1,0.4l0.7,0.7h2l1-1.1l7.2,0.3l1.7,2.5l2,0.8
+														l1.7,1.6l2.1-0.3l0.6-0.7h1.3l1.6,2l3.2,0.2l0.8,1.1l2.3,3.1l1,0.8l1.3-0.1l0.2-2.8l0.6-0.3l0.8,0.1l1.4,1.8l1,0.4l2-0.8l-0.3-0.3
+														l-0.2-2l3.9-1.2l-0.6-2.2l-0.6-3.1l-2.5-3.5l-0.6-2.2h3.9l2.8-2l0.4-2.9l-1.8-2l5.1-4.3v-3.5l-2.6-2.7l-1-3.1l-3.5-3.3l-4.9,2.8
+														l-0.4-1.6l-2.2-0.2l-0.6,1.6l-1.9,0.4l-5.3-0.2l-2.2,1.4l-1.8-1.6l3.1-2.2l-0.2-3.3l-2.3-1.2l-2-2.9l-5.3-0.4L273.7,160.5z">
+                                </path>
+                            </a>
+                            <a class="department" id="dep-36" data-num-dep="36">
+                                <title>36 - Indre</title>
+                                <path d="M254.7,221.4l-1.3,0.4l-2.5-0.2l-2.9,1l-0.7,1.5l-0.3-0.6l-3.4,0.2l-1.7,1.4l-2,0.3l-0.3,1l1.6,2.1l-0.4,1.8
+														l-1.8,0.1v1.5l-1.4,1.3l-1.5,2.5l-1.4-1.3l-2.1-0.4l-3.1,1.1l-0.7,3.5l-1,2.8l-1.5,8l-2.1,2l-1.7,0.2l0.5,0.5v3.7l-0.8,2.3l3.7,2.9
+														l1.9,1.9l3.1,0.4l1.2,4.1l2.1,1.2l-0.4,2.9l-1.6,0.3l0.6,0.1l4.9,0.4l1.8-1.8l3.1,3.1l3.9-4.5l1.8,1.2l2.3-0.2l0.8,0.4l3.5,0.2
+														l1.2-3.1l9.8,1.2l3.7,1l1.7-0.2l0.1-1.6l2-2l-0.4-1.7l-1.1-2.2l0.4-0.8l0.2-2.5l0.7-0.8l0.2-0.6l-1.7-1.5l-0.6-2l-2.7-1.4V251
+														l1.9-1.1v-1.1l-1.8-1.5l-0.6-1l1.4-0.7l-0.1-1.3l2.2-1.8l-0.1-0.8h-1.8l-1.1-1.3v-0.7l1-1.7v-1.3l-2.3-3l0.4-2.7l-1.3-1l-2.7,0.1
+														l-2.1,0.8l-2.8-0.4l-1.4-1.1l-0.3-0.8l2.3-1.8l0.2-2.2l-3-1.7L254.7,221.4z"></path>
+                            </a>
+                            <a class="department prod" id="dep-41" data-num-dep="41" data-lien="15-15">
+                                <title>41 - Loir-et-Cher</title>
+                                <path d="M222.5,172.3l-1.3,1.7l-1.6,2.7l1.9,1.8l-0.2,4.1l-0.8,2.7h-2v3.7l-2.7,3.5l-2.9,1.2l-1.4,1.8l0.6,1.5l9.5,0.3
+														l0.8,0.7l-0.1,0.7l-1.4,0.7l0.3,1.9l1.3,0.8l2-1.4h0.6l2.3,1.7l2,0.2l0.3,5l1.5,4.1v7l1.1,1.7h3.8l2.9,4.3l1.1,0.9l0-0.1l2-0.3
+														l1.7-1.4l3.4-0.2l0.3,0.6l0.7-1.5l2.9-1l2.5,0.2l1.3-0.4l1.7,1.6l3,1.7l2.5-0.2l-0.1-2.5l1.1-1.3l1.1-0.1l1,1.1l3.9-0.4l2.5-1.4
+														l-0.3-1l-0.7-0.8l0.1-1.8l1.8-3.3l2.4-1v-2.1l0.6-1.3l-1.5-0.6l-1-2.1l-2.5-0.7l-0.1-0.8l2.5-2.1l2.8-1.4l-1.6-2.4l-7.2-0.3l-1,1.1
+														h-2l-0.7-0.7l-3.1-0.4l-0.8,1.8l-2,0.6l-1.8-2.1l-0.4-2.4l-1.7-1.4l-2.5-0.3l-1.8-1.3v-1.3l-1.1-2.7l2.2-2.2l-0.3-1.1l-1-1.1h-1.1
+														v-1l1.1-1.9l0.1-1.1h-1.7l-2.5-0.7l-2.4,2.3l-2.7,0.3l-4.3-1.1l-1.3-2.8l-1.7-1l-1-2.3h-2.8l-1.1-0.8l1.7-1l0.1-0.8h-1.8l-3.1,0.6
+														L222.5,172.3z"></path>
+                            </a>
+                            <a class="department prod" id="dep-18" data-num-dep="18" data-lien="15-15">
+                                <title>18 - Cher</title>
+                                <path d="M275.5,200.8l-2.8,1.4l-2.5,2.1l0.1,0.8l2.5,0.7l1,2.1l1.5,0.6l-0.6,1.3v2.1l-2.4,1l-1.8,3.3l-0.1,1.8l0.7,0.8
+														l0.3,1l-2.5,1.4l-3.9,0.4l-1-1.1l-1.1,0.1l-1.1,1.3l0.1,2.5l-2.5,0.2l-0.2,2.2l-2.3,1.8l0.3,0.8l1.4,1.1l2.8,0.4l2.1-0.8l2.7-0.1
+														l1.3,1l-0.4,2.7l2.3,3v1.3l-1,1.7v0.7l1.1,1.3h1.8l0.1,0.8l-2.2,1.8l0.1,1.3l-1.4,0.7l0.6,1l1.8,1.5v1.1l-1.9,1.1v1.7l2.7,1.4
+														l0.6,2l1.7,1.5l-0.2,0.6l-0.7,0.8l-0.2,2.5l-0.4,0.8l1.1,2.2l0.4,1.7l-2,2l-0.1,1.6l4.6-0.6l0.9-2l2.5-2.9l4.9-1l2.6,0.8l2.7-2.1
+														l-0.2-1.6l-1-0.8v-3.1l5.3-5.3l2,2.2l1.8-1.8l1.6-0.2l2.7-3.5l4.5,0.4l0.1,1.1l1.5-4.8l-1-1.8l0.2-2.5l0.6-5.1l-2.2-2.1l0.4-4.7
+														l-2-4.1l-0.2-2.7l-3.5-2.8l-0.6-2.3l1.8-2.5v-3.7l-2-2.4l-2,0.8l-1-0.4l-1.4-1.8l-0.8-0.1l-0.6,0.3l-0.2,2.8l-1.3,0.1l-1-0.8
+														l-2.3-3.1l-0.8-1.1l-3.2-0.2l-1.6-2h-1.3l-0.6,0.7l-2.1,0.3l-1.7-1.6l-2-0.8L275.5,200.8z"></path>
+                            </a>
+                            <a class="department prod" id="dep-21" data-num-dep="21" data-lien="15-NexSIS">
+                                <title>21 - Côte-d'Or</title>
+                                <path d="M363.4,177.3l-0.4,2.5l-2.5,1.4l-6.4,0.2l0.3,1.4l0.2,1.4l-2,1.4v2.4l0.4,0.4h1.6l1,1.7l-0.6,2.8l-2.3,1.7v1.7
+														l0.7,0.6l-0.2,0.4l-1.4,0.6l-0.4,2.1l-2.3,4.8l-1.5,2.3v2.3l0.6,1l-0.8,1.1l-2,1l0.1,2l1.8,1.1l0.7,1.5l-0.3,2.1l-0.4,1.5l1,1.7
+														l2.8,0.6l1.3,2v0.8l-0.8,0.3v2l0.2,0.1l3.8,3.9l3.9-0.1l3.5,2.7l2.5,1.8l0.1,2.4l2.7,0.6l2.3,1.8l5.9-2.1l4.1-1.3l1.8-0.3l0.6-0.8
+														l2,0.1l1.5,1l2.3-0.6l2.3-1.5l1.7,0.2l0-0.2l1.3-0.8l-0.2-1l-0.4-1.2l1-1.6l3.3-1.6v-1.6l1.2-1.6l1.2-1.6l-0.4-1.4l0.6-2.2l0.4-3.1
+														h0.8l-0.2-1.2l-0.8-0.8l-0.2-3.9l-1.8-0.2l-0.4-3.1l-2.2-1l0.8-1l1.2-0.4l2.5-2.9l-0.2-1.6l-1.6-3.1l-2.3-0.4l-0.8,2l-4.3,1l-0.4-1
+														l-3.1-3.9l-1.8,1l-2.3-0.2l-0.8-1.6l-3.1,0.2l-0.2-3.3l-1.8-1.2l2.5-2.7l-4.5-6.1l-3.5-3.7l-3.1-1.8H363.4z">
+                                </path>
+                            </a>
+                            <a class="department" id="dep-58" data-num-dep="58">
+                                <title>58 - Nièvre</title>
+                                <path d="M306.8,203.8l-1,1.5h-1.8l-2.5-0.6l-2.8,0.8l0.2,2l2.3,2.7v3.7l-1.8,2.5l0.6,2.3l3.5,2.8l0.2,2.7l2,4.1
+														l-0.4,4.7l2.2,2.1l-0.6,5.1l-0.2,2.5l1,1.8l-1.5,4.8l0.1,1.5l3.3,1.6l2.3,2.6l2.1-1.2l2-1.2l0.4,1.8h2.9l0.8-1.6l1.8,0.8l0.6,2.5
+														l1.6-0.4l3.7-5.1l1.9,1.4l0.3,0.6l3.1-1.9l1.3,0.2l1,2.4l1.8-0.3l1.4-1.4h1.8l1.4-1.8l1.4-0.3l0.3-1l3.1,0.2l0.2-0.7l-1.4-1.3v-1.3
+														l2-1.1v-0.8l-1.8-1.1l-0.3-2.1l0.2-2l-1.3-0.8l1.1-1.5l1-0.6l0.7-1.7l-1-0.6l-1.1-1.7l1.4-2l2.4-1.4h2.9v-2.2l0.8-0.3v-0.8l-1.3-2
+														l-2.8-0.6l-1-1.7l0.4-1.5l0.3-2.1l-0.5-1.1l-3.1,2.1l-1.3,0.6l-1.7-1.1l0.2-2.8h-1.8l-1.5,1l-0.4-1.3l0.8-1.4l-1-1.3l-1.1,1.7
+														l0.2,1.3l-2.7-0.1l-4.2-3.9l-3.2-0.1v-2.1l-2.3-1.4l-0.4-1.8l-0.7-0.1v3.5l-1.3,0.3l-1.8-0.6l-1.9,1.3l-1.1,0.3l-1.1-1l-1.1,0.6
+														l-2.5-1.7h-1.8l-1.3-0.8l0.3-1.6l-1.4-1.3H306.8z"></path>
+                            </a>
+                            <a class="department" id="dep-71" data-num-dep="71">
+                                <title>71 - Saône-et-Loire</title>
+                                <path d="M351.5,227.8v0.2h-2.9l-2.4,1.4l-1.4,2l1.1,1.7l1,0.6l-0.7,1.7l-1,0.6l-1.1,1.5l1.3,0.8l-0.2,2l0.3,2.1
+														l1.8,1.1v0.8l-2,1.1v1.3l1.4,1.3l-0.2,0.7l-3.1-0.2l-0.3,1l-1.4,0.3l-1.4,1.8h-1.8l-1.4,1.4l-1.8,0.3l-1-2.4l-1.3-0.2l-3.1,1.9
+														l3.6,6.8v2.9l1,1.2h3.3l1.2,1.6h3.1l1.4,1.9l-0.2,7.6l-4.1,3.1l-0.1,0.2l0.3,0l0.6,0.2l0.2,3.1l2.9,0.6l0.4,1.4h1.6l2.3-1.4l6.3,1
+														l1.2,1.2l1.6-1.6h2.2l1.2-6.3l0.8-0.6h1.9l2.4,1.6l1.8-1.6l1.2,1.6l1.8-1.8l2.1-0.2l1,3.1l0.8,3.9l1.4,0.2l1.2-2.8l3.7-14.4
+														l1.4-2.5l2.2-0.2l2.2,1.8l1.6-0.4l1.9-1.4l2,0.4l1.2,2.5l1.1,0.4l5.1-0.6l2-1.6l-0.8-1.2l-2.3-0.8l-0.2-2.7l2-1.4l0.8-3.3l-1.8-3.1
+														l-1.2-1.6l0.6-0.6v-1.9l-1.6-1l-0.4-1.6l4.5-0.6l0.4-1.6h-1.4l-1.2-1.4h-2.2l-1.8-2.9l-1.6-0.2l0.2-2.3l-1.7-0.2l-2.3,1.5l-2.3,0.6
+														l-1.5-1l-2-0.1l-0.6,0.8l-1.8,0.3l-4.1,1.3l-5.9,2.1l-2.3-1.8l-2.7-0.6l-0.1-2.4l-2.5-1.8l-3.5-2.7l-3.9,0.1l-3.8-3.9L351.5,227.8z
+														"></path>
+                            </a>
+                            <a class="department" id="dep-39" data-num-dep="39">
+                                <title>39 - Jura</title>
+                                <path d="M401.2,217.5l0.1,0.5h-0.8l-0.4,3.1l-0.6,2.2l0.4,1.4l-1.2,1.6l-1.2,1.6v1.6l-3.3,1.6l-1,1.6l0.4,1.2l0.2,1
+														l-1.3,0.8l-0.2,2.5l1.6,0.2l1.8,2.9h2.2l1.2,1.4h1.4l-0.4,1.6l-4.5,0.6l0.4,1.6l1.6,1v1.9l-0.6,0.6l1.2,1.6l1.8,3.1l-0.8,3.3
+														l-2,1.4l0.2,2.7l2.3,0.8l0.8,1.2l-2,1.6l-5.1,0.6l2.4,0.9l3.9,5.5l2.5,1.2v2.8l2.9-0.4l3.7-4.1l3.1,1.6v2.3h5.7l8.1-8.9l-0.3-0.2
+														l0.4-4.1l2.9-3.5l-2-0.8l0.2-1.2l-2.4-0.2l-0.2-1.4l1.5-1.5l-0.4-1.5l-0.8-2l3.5-1.1l1.3-1.8l0.3-2.3l-2.8-2.7l-2-0.5l-4.3-1.4
+														v-3.9l-0.3-2.9l-3.5,0.3l-5.5-1.8l0.8-1.9l1.3-3l0.4-1.9l-1.4-1.8l-2.5-1.7l-0.3-2.1l0-1.2l-1.7-0.1l-1,1h-2.5l-1.7-1.4
+														L401.2,217.5z"></path>
+                            </a>
+                            <a class="department" id="dep-51" data-num-dep="51">
+                                <title>51 - Marne</title>
+                                <path d="M337.4,99.3l-2.3,1l0.4,1.9h-4.1l-3.7,2.8v5.3l2.7,1.8l0.8,1.8l-4.5,0.4l-0.6,1.8l1.8,1.2l-0.8,1.2l-1.8,0.8
+														l0.4,1.3h2.5l1,1.4l-1.8,1.2l-1.6,4.1l-2.9,1.4l-1,2.1l-1,1.2l0.2,1.2l-1.6,1l-0.4,2.7l1.6,1l0.8,2.9l-1,1.8l0.6,1.4l2.9-0.2v1
+														l0.8-0.2l3.4,3.6l4.8-0.8l5.6-3.8h3.3l3.4-2.4l4-2.2l3,0.2l0.4,4l3.6,5.3h4l5.6-1.2l4,1.4l4.2-3l0.6-4.9l4.6-0.8l-0.1-3.1l-3.7-2.9
+														l-0.4-1.6l1.4-2.3l-1.2-1l1.2-2.9l2.2-1l1.6-4.9l-3.1,0.2l1.8-1.9l-1.4-4.3l-1.3-2.9l1.8-1.6l-1-0.2l-0.3-1.3c0,0-0.3,0-0.3,0
+														l-1.8-1.6l-2,2h-0.6l-0.8-1l-4.8-0.2l-0.8,1.2H364l-1.2-2.6h-2.6l-0.6,0.6l-2.6-0.2l-3.2-2.4l-2.2-0.6l-0.8-1.2l-4.2-2.6l-4.8-0.1
+														l0.1,1.8l-1.4,0.4L337.4,99.3z"></path>
+                            </a>
+                            <a class="department" id="dep-60" data-num-dep="60">
+                                <title>60 - Oise</title>
+                                <path
+                                    d="M257.2,80.2l-1.3,1.5l-0.8,1.9h1.6l-0.8,2l-0.8,3.9l1.2,1.9v3.3h2l-0.8,1.3l-1.4,2.6l-0.6,1.8l1.8,1.6l0.6,4.5
+														l1,1.6l-1.4,0.4l-1.8-1l-0.3,2.3l0.1-0.2l0.8,1.8l1.2,1.9l5.3,0.4l3.7-0.4l2.5-1.9l3.1,1.9l1.6,1.2l2.3-0.6l2.1-1l4.1,2.2l4.3,2.5
+														l1.4,1.4l2.3-1.6l1.9,1.2l1.2,1l1.8-0.2l1.2-1.6l2.7,1.6l3.3-1.4l1.9,0.6l1.9-1.6l1.2-0.6l0.4,0.3l0.4-2.7l-1.4-1.6l-2.4-1.6
+														l-1,1.6l-0.6,0.2l-0.2-3l1.8-0.4l-0.4-2.8l-2.4-0.4l1.2-2l3.4-0.8l1.2-4.8l1.8-0.8l-2.4-1.8l0.8-1.8l0.4-5.9l-0.8-4.6l-4.1,0.4
+														l-2.8-0.4l-5.2,1.4l-4.4,4.2l-3.6-1.2l-3.6-0.4l-2.8-2.8l-5-1.4l-6.7,0.6l-1.8-1.4h-3.6l-2.6,1l-1.2-0.8v-2.2l-0.4-0.6H257.2z">
+                                </path>
+                            </a>
+                            <a class="department" id="dep-62" data-num-dep="62">
+                                <title>62 - Pas-de-Calais</title>
+                                <path
+                                    d="M269.3,8.7l-10.8,2.1l-8.6,6.6v26.4l-0.1,0.8l3,0.7l1,2.2l2.3-0.6l1.4-1.8l1.8,0.6l3.7,2.9l1.4-0.6l1,2.3
+														l3.5,1.6v1.9l2.6,1l2.5-1l4.9-0.6l1.2,1l2.3-1l1.2,2l-2.9,1.9v2.8l1,1l0.8-0.2l0.6-1.6l1.8-1.2l1.8,1.4l4.1,1.4h1.8v-2l2.6,1.8
+														L295,62l-1.2,1.8l2.2-1.2l1.8-0.8l0.8,1.4v1.4l2.9-1.6h4.7l0.2,0.2l1.2-2.2l-0.6-1l-1.8-0.4h-2l-1.2-0.4l2-1.2l1.8,0.2l1.8-0.2
+														l0.2-3.2l1.2-0.8l0.2-1.8l-2.2-1.4l-2.6-0.2l-0.6-0.4l1.6-1.2l0.4-1.2l-1.4-1l-2-2.4l0.2-1.2l2.6-1.2l0.4-1.4l-1.8-0.8l-1-2.6
+														l-3.6-0.4l-3.6-1l-0.4-4l2.6-1.6l-1-2h-2l-1.4,2.2l-6.2-0.4l-5-1.2l-2.8-3v-2.4l2.2-1l-1.8-1.4l-4.3-0.2l-2.6-6.6L269.3,8.7z">
+                                </path>
+                            </a>
+                            <a class="department" id="dep-59" data-num-dep="59">
+                                <title>59 - Nord</title>
+                                <path d="M285.8,4.1L279.5,7l-9.8,1.6l-0.5,0.1l3.7,5.9l2.6,6.6l4.3,0.2l1.8,1.4l-2.2,1v2.4l2.8,3l5,1.2l6.2,0.4
+														l1.4-2.2h2l1,2l-2.6,1.6l0.4,4l3.6,1l3.6,0.4l1,2.6l1.8,0.8l-0.4,1.4l-2.6,1.2l-0.2,1.2l2,2.4l1.4,1l-0.4,1.2l-1.6,1.2l0.6,0.4
+														l2.6,0.2l2.2,1.4l-0.2,1.8l-1.2,0.8l-0.2,3.2l-1.8,0.2l-1.8-0.2l-2,1.2l1.2,0.4h2l1.8,0.4l0.6,1l-1.2,2.2l1.6,1.6l1.6,0.4l1.6-1
+														h2.2l0.6,1.2l0.8-0.2l2.3-1.4l2.3,1.4l3.1-2.2h1.4l1.6,1.4l3.1-2.2l1.3,0.2l1.2,1l4.3,0.4l0.4,1.8l2.2-1.9h1.2l0.8,2.5l3.7,1
+														l1.1-0.7h-0.3l-0.2-1.9l3.9-2.3l-0.6-3.7l-3.7-1l1-1v-2.7l2.9-2.2l-0.8-1.6l-6.3-4.9l-10.9,0.6l-1.2,1.9H327l0.2-6.8l-3.1-3.7
+														l-2.3,0.4l-1.4-1.6l-3.9,1.8l-1.3-1.3l-2.8-0.4l-0.8-2.5l-0.2-7.8l-1.8-0.8l-0.2-1.2h-1.2l-0.4-2.3l-2.5,0.2l-4.9,1.6l-2.3,2.9
+														h-2.3l-1.6-1.9l-0.6-2.2l-1.9-2.2h-2.8l-1.2-2.1v-3.3l1.3-2.1l-0.8-2.9L285.8,4.1z"></path>
+                            </a>
+                            <a class="department" id="dep-02" data-num-dep="02">
+                                <title>02 - Aisne</title>
+                                <path d="M328.4,62.2l-3.1,2.2l-1.6-1.4h-1.4l-3.1,2.2l-2.3-1.4l-2.3,1.4l-0.8,0.2l-0.6-1.2H311l-1.6,1h-0.1l0.5,2.8
+														l-2.6,2.8v2.6l-1.8,2l0.4,2.4l1,4l1.2,6.8l-0.4,5.9l-0.8,1.8l2.4,1.8l-1.8,0.8l-1.2,4.8l-3.4,0.8l-1.2,2l2.4,0.4l0.4,2.8l-1.8,0.4
+														l0.2,3l0.6-0.2l1-1.6l2.4,1.6l1.4,1.6l-0.4,2.7l1.8,1.3l0.6,4.3l5.3,5.1l1.8,0.6l1,2.3l3.3,0.7l0.4-0.5l1-2.1l2.9-1.4l1.6-4.1
+														l1.8-1.2l-1-1.4h-2.5l-0.4-1.3l1.8-0.8l0.8-1.2l-1.8-1.2l0.6-1.8l4.5-0.4l-0.8-1.8l-2.7-1.8V105l3.7-2.8h4.1l-0.4-1.9l2.3-1
+														l3.3,2.2l1.4-0.4l-0.2-6.7l0.6-2.3l0.8-2.7l-2.6-1.4l0.6-1.6l3.7-0.8v-2.5l2.9-1.6l0.8-2.3l-1-1.6l0.2-2.9l1.8-1.6l-1.8-3.3
+														l0.5-3.5h-4l-1.1,0.7l-3.7-1l-0.8-2.5h-1.2l-2.2,1.9l-0.4-1.8l-4.3-0.4l-1.2-1L328.4,62.2z"></path>
+                            </a>
+                            <a class="department" id="dep-80" data-num-dep="80">
+                                <title>80 - Somme</title>
+                                <path d="M249.8,44.5l-0.5,6.4l4.3,3.9v2l-5.3-3.1l-6.3,7.8l1.7,0.7l2.2-0.2l1,1.9l8.6,8.4l0.6,3.5l1.9,3.5l-0.7,0.8
+														h2.5l0.4,0.6V83l1.2,0.8l2.6-1h3.6l1.8,1.4l6.7-0.6l5,1.4l2.8,2.8l3.6,0.4l3.6,1.2l4.4-4.2l5.2-1.4l2.8,0.4l4.1-0.4l-0.4-2.2l-1-4
+														l-0.4-2.4l1.8-2v-2.6l2.6-2.8l-0.5-2.8l-1.5-0.4l-1.8-1.8h-4.7l-2.9,1.6v-1.4l-0.8-1.4l-1.8,0.8l-2.2,1.2L295,62l-0.2-1.6l-2.6-1.8
+														v2h-1.8l-4.1-1.4l-1.8-1.4l-1.8,1.2l-0.6,1.6l-0.8,0.2l-1-1v-2.8l2.9-1.9l-1.2-2l-2.3,1l-1.2-1l-4.9,0.6l-2.5,1l-2.6-1v-1.9
+														l-3.5-1.6l-1-2.3l-1.4,0.6l-3.7-2.9l-1.8-0.6l-1.4,1.8l-2.3,0.6l-1-2.2L249.8,44.5z"></path>
+                            </a>
+                            <a class="department" id="dep-08" data-num-dep="08">
+                                <title>08 - Ardenne</title>
+                                <path
+                                    d="M367.6,55.8l-2,2.9l-1.8,1.8v1.8v2.3l-2.3,1.6l-4.3,1.4l-2.3,1l-2.8-2.2h-3.7l-0.5,3.5l1.8,3.3l-1.8,1.6
+														l-0.2,2.9l1,1.6l-0.8,2.3l-2.9,1.6v2.5l-3.7,0.8l-0.6,1.6l2.6,1.4l-0.8,2.7l-0.6,2.3l0.1,4.9l4.8,0.1l4.2,2.6l0.8,1.2l2.2,0.6
+														l3.2,2.4l2.6,0.2l0.6-0.6h2.6l1.2,2.6h1.4l0.8-1.2l4.8,0.2l0.8,1h0.6l2-2l1.8,1.6c0,0,0.2,0,0.3,0l-0.1-0.8l2.3-1.2l1.2-1.2
+														l-0.8-1.9l-0.2-1.4l2.2-1.8l0.8-3.9l-2.3-2.9l0.8-1.4l2-3.7l0.6,0.8h2.9l1.4,1.3l1.8-1.2l1.4-2.3l-1.4-0.2l-0.8-3.9l-1.6-1.2
+														l-5.5-0.6l-1-2.5l-1.8-1.2l-6.3-0.8l-0.4-4.5l0.8-0.8v-1.8l-3.1-2l0.6-2.2l0.8-1.9l-1.4-1.2l2.2-1.9v-3.5l-0.8-0.6H367.6z">
+                                </path>
+                            </a>
+                            <a class="department" id="dep-10" data-num-dep="10">
+                                <title>10 - Aube</title>
+                                <path d="M349.3,138.7l-4,2.2l-3.4,2.4h-3.3l-5.6,3.8l-4.8,0.8l-3.4-3.6l-0.8,0.2v0.6l-2.7,1.2l-0.2,2.3l-1.4,1.8
+														l-0.8,3.9l-0.4,3.3l1.2,1h2.3l5.1,5.3l-0.6,5.3l3.5,2.7l2-1.4l3.1,3.7l0.4,3.5l2.2,2.9l1,2.2l7.8,0.4l3.9-2l1.2,2.2l1.4,0.2l1-2.2
+														l6.4-0.2l2.5-1.4l0.4-2.5h5.7l0.8,0.4l-0.7-2.5l-1.6-1l2.2-2l3.4-0.2l1.2-1.8l-0.2-7.1l-0.8-4.2l-3.4-1.2l-3.6-5l0.2-3l1-2.2
+														l-1.8-0.6l-5.6,1.2h-4l-3.6-5.3l-0.4-4L349.3,138.7z"></path>
+                            </a>
+                            <a class="department" id="dep-52" data-num-dep="52">
+                                <title>52 - Haute-Marne</title>
+                                <path d="M379.1,139.7l-4.6,0.8l-0.6,4.9l-4.2,3l-2.2-0.8l-1,2.2l-0.2,3l3.6,5l3.4,1.2l0.8,4.2l0.2,7.1l-1.2,1.8
+														l-3.4,0.2l-2.2,2l1.6,1l0.7,2.5l2.3,1.3l3.5,3.7l4.5,6.1l-2.5,2.7l1.8,1.2l0.2,3.3l3.1-0.2l0.8,1.6l2.3,0.2l1.8-1l3.1,3.9l0.4,1
+														l4.3-1l0.8-2l0.2,0v-2l2.7-1.2l3.1,1.2l2.9-1.2h1.8l0.6-3.9l1-1.2l-1.8-0.2l-0.2-2.3l2.7-0.6l0.2-1.6h2.8v-2.5l2.2-0.8l-0.6-1.6
+														l0.6-0.4l-1.8-1.4l-2.1,0.8v-4.1L405,173l1.2-5.3l1.8-1.2l-0.6-1.8l-2.6-0.4l-0.6-2.6h-2.3l-2.8-3.7l-3.1-0.2l-1.3-1.9l1.8-1.8
+														l-4.1-4.5l-1.8-0.6l-4.7-2.3l-2.5-2.7l-4.1-0.6L379.1,139.7z"></path>
+                            </a>
+                            <a class="department" id="dep-67" data-num-dep="67">
+                                <title>67 - Bas-Rhin</title>
+                                <path
+                                    d="M480.7,112.3l-3.7,1l-1.7,3v2.9l-1.6,1.4h-1.4l-2.5-1.8l-2,1.4h-2.3l-1.9-1.9l-3.7-0.6l-2.2-1l-0.8-2.9
+														l-1.8,1.9l-1,4.5l-2.6,0.8v2.5l2.6,1.2l1.9,1.4l-0.8,1.8l1.8,1.2l3.1-2.3l5.4,3.1l-2.3,4.3l0.2,1.4l1.6,1.6l-1.2,4.1L460,145
+														l-2.2-0.2l1.4,1.3l-0.8,3.5l0.8,5.3l3.7,1l-0.3,0.7l2.9-0.2l1.7,2.1l1.5,1.9l3.8-0.2l1.7,5l3,1.3l0-0.6l5.1-10l-0.6-5.7l2.3-7.6
+														l0.6-6.7l5.1-3.7v-2.3l2-2.6h1.6l1.8-1.8l-0.4-3.3l1.8-4.7l2.7-0.6l-2.7-2.2l-4.9-0.6l-4.3-2.2l-2.9,1.8l-1.6-1.8H480.7z">
+                                </path>
+                            </a>
+                            <a class="department" id="dep-54" data-num-dep="54">
+                                <title>54 - Meurthe-et-Moselle</title>
+                                <path d="M401.6,88.4l-2.3,2.2l-3.3,0.2l-1.2,1.2h-0.3l-0.1,2.3l1.2,1.9l-0.4,1.2l-0.4,1.3l0.2,0.8l1-0.8l0.9-1.7
+														l1.9-0.2l3.3-1l1.7,1.3l0.8,1.5l0.6,1.7v1.7l0.9,0.8v1.3l-0.9,1.2l-0.2,2.5l0.8,1.2l0.2,1.5l0.2,2.5l1.2,1l1.7,0.8l-0.8,1.5
+														l2.1,1.9l-1.9,2.1l0.4,1.3l1.9,0.9v1h-2.3l-1,1.3l0.2,1l1.5,1.5l-1.3,3.6l-1.5,3.4l0.8,2.1v3.4l0.8,1.7h1.1l0.6,1h-1.7l-1.5,0.8
+														v1.2l1.9,1.7v2.7l1.9-0.6l2.9,0.2l0.2,3.1l1.2,0.4l-1.3,0.9l-0.2,1l2.1,0.4l1.3,1.7l6.3-0.4l1.3-2.5h2.9l1.2-0.9l1.9,1.2l1.7-0.6
+														l2.5,0.2l2.1-0.8l2.1-1.5l1.2,1.2l0.2-2.7l1.5-0.6l0.8,2.5l2.3,0.2l2.3,0.6l0.9,0.2l3.3-1.5l1.7-1.2l1.5-1.9l3.1-1.2l2-0.4
+														l-1.1-1.1l2.2,0.2l0.4-0.4l-2.3-0.8l-3.3-2.3l-2.9-2.1h-3.4l-3.6-2.1l-2.9-0.2v-0.8l-4.4-2.7l-5-2.1h-2.5l-0.9-2.7l-3.8-4.8h-3.8
+														l-1.5-2.1H417l0.2-3.1l-4-2.5l0.2-2.5h2.1v-2.1l0.8-1.5l-1.7-1.7l1.5-2.7l-1.2-3.1l-0.9-0.8l-2.5-5.3l1-1.5c0,0-0.1-1.3-0.2-2.9
+														h-2.6l-3.5-3.9H401.6z"></path>
+                            </a>
+                            <a class="department prod" id="dep-77" data-num-dep="77" data-lien="15-15">
+                                <title>77 - Seine-et-Marne</title>
+                                <path d="M307.5,116.5l-1.2,0.6l-1.9,1.6l-1.9-0.6l-3.3,1.4l-2.7-1.6l-1.2,1.6l-1.8,0.2l-1.2-1l-1.9-1.2l-2.3,1.6
+														l-0.1-0.1l-0.8,5.4l1.2,6.9v4.6l-1.5,3.8l0.4,2.7l-1.7,1.3l0.9,5.2l-0.8,1.1l-0.6,5.2l1.3,1.7l-4.4,2.9v3.9l1.2,1.8l2.3,1.2
+														l0.2,3.3l-3.1,2.2l1.8,1.6l2.2-1.4l5.3,0.2l1.9-0.4l0.6-1.6l2.2,0.2l0.4,1.6l4.9-2.8l1.8-2.1l2.3-2.8l-1.6-1.8l1.4-2.9l3.5-1.8
+														l7.6,0.4l1.8-1.3l0.2,0.2l0.4-3.3l0.8-3.9l1.4-1.8l0.2-2.3l2.7-1.2v-1.6l-2.9,0.2l-0.6-1.4l1-1.8l-0.8-2.9l-1.6-1l0.4-2.7l1.6-1
+														l-0.2-1.2l0.6-0.7l-3.3-0.7l-1-2.3l-1.8-0.6l-5.3-5.1l-0.6-4.3L307.5,116.5z"></path>
+                            </a>
+                            <a class="department" id="dep-68" data-num-dep="68">
+                                <title>68 - Haut-Rhin</title>
+                                <path
+                                    d="M465.6,156.5l-2.9,0.2l-1.8,4.2l-2.3,4.7l0.6,2.9l-1.9,4.5l-3.3,2.9l-0.2,7.6l-2.4,2.1l0.1,0.1l0.8,1.6
+														l3.1,0.2l3.5,2.8l0.6,1.3l-0.2,2.3l-1,1.8l0.4,2.3l2.8-0.4l0.6,2.2l1,4.2l2.3-0.4l-0.4,2.1l1.4,1.2l7.2-0.2l3.7-2.9l0.2-4.3l2-2.5
+														l-2.6-2.9l-1.3-3.1l1.6-2.1v-4.9l1-2.3v-3.9l1.8-2.5l-1.9-2.7l-0.2-5.6l-3-1.3l-1.7-5l-3.8,0.2l-1.5-1.9L465.6,156.5z">
+                                </path>
+                            </a>
+                            <a class="department" id="dep-55" data-num-dep="55">
+                                <title>55 - Meuse</title>
+                                <path d="M390.1,86.5l-1.4,2.3l-1.8,1.2l-1.4-1.3h-2.9l-0.6-0.8l-2,3.7l-0.8,1.4l2.3,2.9l-0.8,3.9l-2.2,1.8l0.2,1.4
+														l0.8,1.9l-1.2,1.2l-2.3,1.2l0.4,2.2l1,0.2l-1.8,1.6l1.3,2.9l1.4,4.3l-1.8,1.9l3.1-0.2l-1.6,4.9l-2.2,1l-1.2,2.9l1.2,1l-1.4,2.3
+														l0.4,1.6l3.7,2.9l0.2,6.8l4.1,0.6l2.5,2.7l4.7,2.3l1.8,0.6l4.1,4.5l-0.4,0.4l3.4-0.4v-1.7l3.8-0.8v-1.3h0.9v1.1l3.1-0.9l1.2-1.6
+														l-0.2,0.1v-2.7l-1.9-1.7v-1.2l1.5-0.8h1.7l-0.6-1h-1.1l-0.8-1.7v-3.4l-0.8-2.1l1.5-3.4l1.3-3.6l-1.5-1.5l-0.2-1l1-1.3h2.3v-1
+														l-1.9-0.9l-0.4-1.3l1.9-2.1l-2.1-1.9l0.8-1.5l-1.7-0.8l-1.2-1l-0.2-2.5l-0.2-1.5l-0.8-1.2l0.2-2.5l0.9-1.2v-1.3l-0.9-0.8v-1.7
+														l-0.6-1.7l-0.8-1.5l-1.7-1.3l-3.3,1l-1.9,0.2l-0.9,1.7l-1,0.8l-0.2-0.8l0.4-1.3l0.4-1.2l-1.2-1.9l0.1-2.3h-0.9l-0.8-3.7l-1.6-1.6
+														L390.1,86.5z"></path>
+                            </a>
+                            <a class="department" id="dep-57" data-num-dep="57">
+                                <title>57 - Moselle</title>
+                                <path d="M423.1,90.4l-2.9,0.2l-2.3,2l-0.6,1h-3.3l-1.2-1.2h-0.5c0.1,1.7,0.2,2.9,0.2,2.9l-1,1.5l2.5,5.3l0.9,0.8
+														l1.2,3.1l-1.5,2.7l1.7,1.7l-0.8,1.5v2.1h-2.1l-0.2,2.5l4,2.5l-0.2,3.1h3.1l1.5,2.1h3.8l3.8,4.8l0.9,2.7h2.5l5,2.1l4.4,2.7v0.8
+														l2.9,0.2l3.6,2.1h3.4l2.9,2.1l3.3,2.3l2.3,0.8l3.5-3.5l1.2-4.1l-1.6-1.6l-0.2-1.4l2.3-4.3l-5.4-3.1l-3.1,2.3l-1.8-1.2l0.8-1.8
+														l-1.9-1.4l-2.6-1.2V121l2.6-0.8l1-4.5l1.8-1.9l0.8,2.9l2.2,1l3.7,0.6l1.9,1.9h2.3l2-1.4l2.5,1.8h1.4l1.6-1.4v-2.9l1.7-3l-0.4,0.1
+														l-1.3-1.9l-3.9-2.3L470,107l-4.7,0.4l-2.8,2.5l-6.6,0.2l-2-1.4c-0.1-0.2-1.1-1.9-1.9-2.4c0,0-0.1,0-0.1-0.1c0,0-0.1,0-0.1,0
+														c0,0-0.1,0-0.1,0c0,0,0,0,0,0c0,0-0.1,0-0.1,0c-0.9,0-2.7-1-2.9-1.2l-2.8,1.2l-0.2,2.3l-3.3,0.4l-2-3.7l-1.2-0.4v-2.7l-2.8-1.2
+														l-0.2-4.7l-2-1.9l-4.1-2h-1.9l-0.6,0.4h-2L423.1,90.4z"></path>
+                            </a>
+                            <a class="department" id="dep-88" data-num-dep="88">
+                                <title>88 - Vosges</title>
+                                <path d="M459,145.9l-2,0.4l-3.1,1.2l-1.5,1.9l-1.7,1.2l-3.3,1.5l-0.9-0.2l-2.3-0.6l-2.3-0.2l-0.8-2.5l-1.5,0.6
+														l-0.2,2.7l-1.2-1.2l-2.1,1.5l-2.1,0.8l-2.5-0.2l-1.7,0.6l-1.9-1.2l-1.2,0.9h-2.9l-1.3,2.5l-6.3,0.4l-1.3-1.7l-2.1-0.4l0.2-1
+														l1.3-0.9l-1.2-0.4l-0.2-3.1l-2.9-0.2l-1.7,0.5l-1.2,1.6l-3.1,0.9v-1.1h-0.9v1.3l-3.8,0.8v1.7l-3.4,0.4l-1.3,1.3l1.3,1.9l3.1,0.2
+														l2.8,3.7h2.3l0.6,2.6l2.6,0.4l0.6,1.8l-1.8,1.2L405,173l5.5,2.7v4.1l2.1-0.8l1.8,1.4l1.3-0.8l-0.8-1.2l1-0.6l1.3,1.6l2-1.4l0.6-1.9
+														l3.7-0.6l1,0.8l-0.2,2.2l2.5,1.9l1.6-0.2l1.8-1.4h4.1l2.9,3.3h1l1.6-1l0.2-1.2l1.6-0.8l1.8,1.2l1.8,2l6.2,3.3l2.4-2.1l0.2-7.6
+														l3.3-2.9l1.9-4.5l-0.6-2.9l2.3-4.7l2.2-4.9l-3.7-1l-0.8-5.3l0.8-3.5L459,145.9z"></path>
+                            </a>
+                            <a class="department" id="dep-91" data-num-dep="91">
+                                <title>91 - Essonne</title>
+                                <path d="M274.2,136.4l-1.8,0.8l-1.9,0.8l-0.4,2.1l-2.9,1.3l-0.4,2.1l1.3,2.3l-1.9,2.7h-2.8l1.1,1.7l-1.3,1.5l-0.5,3.1
+														l0.9,0.2l0.4,2.5l0.4,0.6l0.4,5.3l6.3-0.6l2.5-2.3l2.2,1.8l5.3,0.4l0.8,1.1v-3.9l4.4-2.9l-1.3-1.7l0.6-5.2l0.8-1.1l-0.9-5.2
+														l1.7-1.3l-0.3-2.4l-2.2-1h-3.6l-2.1-1.2l-1.5,0.8L274.2,136.4z"></path>
+                            </a>
+                            <a class="department prod" id="dep-78" data-num-dep="78" data-lien="15-15">
+                                <title>78 - Yvelines</title>
+                                <path d="M251.5,118.2l-0.1,0.1l-5.5,1.6l-0.8,1l1,1.6v1.6l1.8,0.4l-1,1l0.1,0.9l0.1-0.1l1.9,1.9l0.6,2.3l1.6,1.6
+														l-0.8,2.2v1.9l1.4,1.6l-1.4,2.3l1.4,3.3l2.7,1.9l0.4,2.2l2.3,0.4l0.6,4.3l1.8,2.2l3.2,0.6l0.5-3.1l1.3-1.5l-1.1-1.7h2.8l1.9-2.7
+														l-1.3-2.3l0.4-2.1l2.9-1.3l0.4-2.1l1.9-0.8l1.8-0.8l0.3,0.2v-0.2l-1.8-2l-1.1-3l1.8-3.8l-0.9-2.9l-3.4-2.1l-4.8-0.2l-4.5-2.9
+														l-3.6,0.7L251.5,118.2z"></path>
+                            </a>
+                            <a class="department prod" id="dep-95" data-num-dep="95" data-lien="15-15">
+                                <title>95 - Val-d'Oise</title>
+                                <path d="M255.6,109.7l-1.6,1.9l-1.2,4.3l-1.3,2.2l4.8,2.1l3.6-0.7l4.5,2.9l4.8,0.2l3.4,2.1l0.9,2.9l0,0.1l0.4-0.1
+														l3.5-1.9l5.3-0.3l2.9-1.3l1.8-1.3l0.6-3.8l-1.3-1.3l-4.3-2.5l-4.1-2.2l-2.1,1l-2.3,0.6l-1.6-1.2l-3.1-1.9l-2.5,1.9l-3.7,0.4
+														l-5.3-0.4l-1.2-1.9L255.6,109.7z"></path>
+                            </a>
+                            <a class="department" id="dep-93" data-num-dep="93">
+                                <title>93 - Seine-Saint-Denis</title>
+                                <path d="M287.3,122.8l-1.8,1.3l-2.9,1.3l-5.3,0.3l0.2,0.7l0.4,0.1l0.4,0.6l-0.4,0.9l-0.5,0.1l0.4,0.9l2.5,0l0.8,1.3
+														l0.2,1.8l0.9-0.1l0.8-0.7l1.2,0.1l1.5,0.9l0.9,1l0.4,0.2l0.3,0.5l1,0.3v-2.8l-1.2-6.9L287.3,122.8z"></path>
+                            </a>
+                            <a class="department" id="dep-75" data-num-dep="75">
+                                <title>75 - Paris</title>
+                                <path
+                                    d="M280.3,129.1l-2.5,0l-1.1,0.5l-0.5,0.6l-1,0.1l-0.9,1.1l0,0.6l0.2,0.7l1.6,0.4l1.9,1l1.2,0.1l0.8-0.2l0.8-0.6
+														l0.3,0.3l1.8,0.3l0.3-0.7v-0.7l-0.3-0.1l-1.3,0.1l0.1,0.3l-0.2,0.2h-0.4l0.2-0.4l0.1-0.4h-0.1l-0.2-1.8L280.3,129.1z">
+                                </path>
+                            </a>
+                            <a class="department" id="dep-92" data-num-dep="92">
+                                <title>92 - Hauts-de-Seine</title>
+                                <path
+                                    d="M277.3,125.8l-3.5,1.9l-0.4,0.1l-1.7,3.8l1.1,3l1.8,2v0.2l2.7,1.9l0.7-0.3l-0.5-0.9l0.5-1.5l-0.3-0.5l0.3-1.2
+														h-0.1l-1.9-1l-1.6-0.4l-0.2-0.7l0-0.6l0.9-1.1l1-0.1l0.5-0.6l1.1-0.5l-0.4-0.9l0.5-0.1l0.4-0.9l-0.4-0.6l-0.4-0.1L277.3,125.8z">
+                                </path>
+                            </a>
+                            <a class="department" id="dep-94" data-num-dep="94">
+                                <title>94 - Val-de-Marne</title>
+                                <path d="M282.9,131.3l-0.8,0.7l-0.8,0.1l-0.1,0.4l-0.2,0.4h0.4l0.2-0.2l-0.1-0.3l1.3-0.1l0.3,0.1v0.7l-0.3,0.7
+														l-1.8-0.3l-0.3-0.3l-0.8,0.6l-0.8,0.2L278,134l-0.3,1.2l0.3,0.5l-0.5,1.5l0.5,0.9l0.9-0.4l2.1,1.2h3.6l2.2,1l0-0.2l1.5-3.8v-1.8
+														l-1-0.3l-0.3-0.5l-0.4-0.2l-0.9-1l-1.5-0.9L282.9,131.3z"></path>
+                            </a>
+                            <a class="department" id="dep-25" data-num-dep="25">
+                                <title>25 - Doubs</title>
+                                <path
+                                    d="M447.4,199.7l-0.2,0.2H445l-1.2,1.6l-1.5,0.8v2l-3.7,0.4l-2-1.4l-2.7,0.4l-2.5,2l-1.8,3.1l-1.8,0.6l-0.8,2.1
+														l-2.3,0.4l-3.1,2.5l-4.1-0.1l-1.3,1h-1.1l-3.9,3.2l-1.8-0.1l0,1.2l0.3,2.1l2.5,1.7l1.4,1.8l-0.4,1.9l-1.3,3l-0.8,1.9l5.5,1.8
+														l3.5-0.3l0.3,2.9v3.9l4.3,1.4l2,0.5l2.8,2.7l-0.3,2.3l-1.3,1.8l-3.5,1.1l0.8,2l0.4,1.5l-1.5,1.5l0.2,1.4l2.4,0.2l0-0.2l12.1-11.3
+														l-0.4-9.4l4.3-2.1l2.9-1.4l2.7-2.5l0.2-3.7l2.7-1.4l6.3-7.2l-1-2.3l2.2-1l2.5-3.1l-1.4-1.4l-4.7,1l-0.2-0.8l4.3-5L447.4,199.7z">
+                                </path>
+                            </a>
+                            <a class="department" id="dep-90" data-num-dep="90">
+                                <title>90 - Territoire de Belfort</title>
+                                <path d="M451.4,186l-1.8,0.9l-1.5,1.1v2.5l0.8,3v1.9l-0.5,3.1l-1.1,1.1l12,5.4l0.8-0.9l2.6-0.4l-1-4.2l-0.6-2.2
+														l-2.8,0.4l-0.4-2.3l1-1.8l0.2-2.3l-0.6-1.3l-3.5-2.8l-3.1-0.2L451.4,186z"></path>
+                            </a>
+                        </g>
+                        <a class="department" id="dep-93zoom" data-num-dep="93">
+                            <title>93 - Seine-Saint-Denis</title>
+                            <path d="M621.1,58l-7.9,5.6L601,69.3l-22.4,1.5l0.7,3.1l1.9,0.4l1.7,2.7l-1.7,3.7l-2.3,0.4l1.6,3.9l10.8-0.1l3.5,5.3
+													l0.7,7.5l3.7-0.5l3.5-2.8l5.2,0.3l6.5,3.7l3.7,4.1l1.7,0.8l1.1,2l4.1,1.1V94.1l-4.9-29.4L621.1,58z"></path>
+                        </a>
+                        <a class="department" id="dep-75zoom" data-num-dep="75">
+                            <title>75 - Paris</title>
+                            <path
+                                d="M591.2,84.7l-10.8,0.1l-4.8,2.1l-2,2.7l-4.4,0.3l-4,4.5l0.1,2.5l0.9,2.9l6.7,1.9l8.1,4.1l5.2,0.3l3.5-0.9
+													l3.6-2.5l1.2,1.1l7.7,1.1l1.3-2.8v-2.8l-1.3-0.5L597,99l0.4,1.3l-0.9,0.8h-1.7l0.7-1.7l0.3-1.9h-0.3l-0.7-7.5L591.2,84.7z">
+                            </path>
+                        </a>
+                        <a class="department" id="dep-92zoom" data-num-dep="92">
+                            <title>92 - Hauts-de-Seine</title>
+                            <path
+                                d="M578.5,70.7l-15,8L562,79l-7.3,16l4.7,12.7l7.5,8.4v0.9l11.6,8.1l2.8-1.5l-2.1-4l2.1-6.3l-1.3-2.3l1.5-5.2h-0.3
+													l-8.1-4.1l-6.7-1.9l-0.9-2.9l-0.1-2.5l4-4.5l4.4-0.3l2-2.7l4.8-2.1l-1.6-3.9l2.3-0.4l1.7-3.7l-1.7-2.7l-1.9-0.4L578.5,70.7z">
+                            </path>
+                        </a>
+                        <a class="department" id="dep-94zoom" data-num-dep="94">
+                            <title>94 - Val-de-Marne</title>
+                            <path d="M602.6,94.2l-3.5,2.8l-3.5,0.5l-0.3,1.9l-0.7,1.7h1.7l0.9-0.8L597,99l5.3-0.3l1.3,0.5v2.8l-1.3,2.8l-7.7-1.1
+													l-1.2-1.1l-3.6,2.5l-3.5,0.9l-4.9-0.3l-1.5,5.2l1.3,2.3l-2.1,6.3l2.1,4l3.7-1.9l8.9,4.9h15.5l9.2,4.3l-0.1-0.9l6.5-16.4v-7.5
+													l-4.1-1.1l-1.1-2l-1.7-0.8l-3.7-4.1l-6.5-3.7L602.6,94.2z"></path>
+                        </a>
+                        <g>
+                            <a class="department" id="dep-971" data-num-dep="971">
+                                <title>971 - Guadeloupe</title>
+                                <path
+                                    d="M575.3,249.2c0.7-2.7-0.7-5.1-1.7-7.5c-1.5-3.6-0.2-6.7,1.3-9.9c0.1-0.3,0.5-0.4,0.8-0.4
+														c3.6-0.1,6.8,1.3,9.7,3.3c0.8,0.6,1.1,1.7,1.5,2.6c0.3,0.5,0.6,1,1.2,0.7c0.5-0.2,1.4,0,1.3-1.1c-0.1-1.7,0.9-2.6,2.5-2.8
+														c0.6-0.1,1.2-0.4,1.6-0.8c1.1-1,1.2-2.3-0.2-2.9c-1.9-0.8-2-2.3-2.3-3.9c-0.1-0.4,0.1-0.6,0.3-0.9c1.2-1.6,2.3-3.2,3.5-4.8
+														c0.4-0.6,0.8-0.8,1.3,0c0.7,1,1.6,1.8,2.3,2.8c1.3,1.8,2.3,3.7,2.1,6.2c-0.2,2.2,0.8,3.5,3,3.8c4.5,0.6,7.8,3.3,11.1,6.1
+														c0.7,0.6,0.4,0.8-0.2,0.9c-2.1,0.4-4.1,1.3-6.3,0.8c-1.6-0.4-3.2,0-4.7,0.6c-1.5,0.6-3.1,0.9-4.5,1.6c-2.1,1-4.1,0.6-6.1,0
+														c-1-0.3-1.3-1.5-2-2.1c-0.3-0.3-0.3-0.9-1-0.6c-0.6,0.3-1,0.5-1,1.3c0.1,0.9,0.1,1.8,0,2.7c0,0.7,0.2,1.2,0.8,1.5
+														c0.9,0.4,1.1,1.1,1.1,2.1c-0.1,2-0.1,4.1,0,6.1c0,1-0.3,1.5-1.1,2.1c-2.1,1.3-4.2,2.7-6.3,4.1c-0.8,0.6-1.8,0.7-2.8,1
+														c-0.5,0.2-0.7-0.3-0.9-0.6c-1.1-2.7-2.4-5.4-4.1-7.9C574.9,252,575.6,250.6,575.3,249.2z M612.5,240c-2.6-2.7-5.7-4.4-9.7-5.2
+														c-2.4-0.5-3.4-1.8-3.5-4.4c0-1,0.2-2.1-0.3-3.1c-0.9-1.7-1.9-3.2-3.2-4.7c-0.5-0.5-0.7-0.3-1,0.1c-0.6,0.9-1.3,1.7-1.9,2.6
+														c-1,1.4-0.7,2.9,0.8,3.8c2.4,1.4,2.6,3.4,0.4,5c-0.7,0.5-1.3,0.9-2.1,1.1c-1,0.2-1.5,0.7-1.5,1.8c0,1.2-0.5,2-1.8,2.1
+														c-0.3,0-0.7,0-0.9,0.1c-1.2,0.5-1.8,0-2.1-1.1c-0.6-2-2.1-3.3-4-4.1c-0.3-0.1-0.6-0.3-1-0.5c-1.4-0.9-2.9-0.7-4.4-0.9
+														c-0.4-0.1-0.7,0.1-0.9,0.5c-1.4,2.7-2.1,5.5-0.7,8.4c1.2,2.5,1.8,5.1,1.5,8c-0.1,0.5,0,1.1,0,1.6c0,0.7,0.1,1.3,0.5,1.8
+														c1.4,1.9,2.4,4,3.3,6.2c0.6,1.4,0.9,1.5,2.2,0.7c2.1-1.3,4.1-2.7,6.2-4.1c0.6-0.4,0.7-0.8,0.7-1.5c0-1.7-0.1-3.4,0-5.1
+														c0-0.9-0.2-1.6-0.9-2.1c-0.8-0.5-1-1.2-0.9-2.1c0.1-0.6,0.1-1.3,0-1.9c-0.3-1.6,0.4-2.6,1.9-3.4c1-0.5,1.4-0.4,1.9,0.5
+														c0.9,1.5,2,2.9,4,2.9c0.6,0,1.2,0.1,1.8-0.1c2.3-0.8,4.5-1.4,6.8-2.3c1.4-0.5,2.7-0.6,4.1-0.3C609.6,240.7,611.1,240.6,612.5,240z">
+                                </path>
+                                <path d="M609.6,267.9c-1.3-0.6-2.8-1.1-4.4-1.4c-0.4-0.1-0.4-0.7-0.6-1.1c-1.3-2.4-1.3-4.4,1.1-6.1
+														c0.2-0.1,0.3-0.4,0.4-0.5c0.8-0.9,1.6-2.5,2.5-2.4c1.6,0.3,3.2,1.2,4.3,2.6c0.3,0.4,0.6,0.8,0.9,1.2c0.5,0.6,1.4,1.2,1.2,2
+														c-0.4,1.2-0.7,2.4-1.8,3.2c-0.9,0.6-1.7,1.5-2.6,2.2C610.4,267.7,610.1,268,609.6,267.9z M613.5,262.5c0-0.3,0.1-0.5-0.1-0.8
+														c-0.7-0.8-1.4-1.8-2.2-2.5c-2-1.7-2.3-1.6-4.1,0.3c-0.2,0.2-0.3,0.4-0.6,0.6c-1.9,1.3-1.9,2.9-0.9,4.8c0.1,0.3,0.2,0.7,0.5,0.7
+														c2,0.3,4,1.9,5.8-0.6C612.4,264.2,613.3,263.6,613.5,262.5z"></path>
+                                <path d="M612.5,240c-1.5,0.7-3,0.7-4.5,0.4c-1.4-0.2-2.7-0.2-4.1,0.3c-2.2,0.8-4.5,1.5-6.8,2.3
+														c-0.6,0.2-1.2,0.1-1.8,0.1c-2.1-0.1-3.1-1.4-4-2.9c-0.5-0.9-0.9-1-1.9-0.5c-1.5,0.8-2.1,1.8-1.9,3.4c0.1,0.6,0.1,1.3,0,1.9
+														c-0.1,0.9,0.2,1.6,0.9,2.1c0.7,0.5,1,1.2,0.9,2.1c-0.1,1.7,0,3.4,0,5.1c0,0.6-0.1,1.1-0.7,1.5c-2.1,1.3-4.1,2.7-6.2,4.1
+														c-1.3,0.8-1.7,0.7-2.2-0.7c-0.9-2.2-1.9-4.3-3.3-6.2c-0.4-0.5-0.6-1.1-0.5-1.8c0-0.5,0-1.1,0-1.6c0.3-2.8-0.3-5.4-1.5-8
+														c-1.4-2.9-0.7-5.7,0.7-8.4c0.2-0.4,0.5-0.5,0.9-0.5c1.5,0.2,3.1,0.1,4.4,0.9c0.3,0.2,0.6,0.4,1,0.5c1.9,0.8,3.3,2,4,4.1
+														c0.3,1.1,1,1.6,2.1,1.1c0.3-0.1,0.6-0.1,0.9-0.1c1.4,0,1.9-0.9,1.8-2.1c0-1,0.5-1.6,1.5-1.8c0.8-0.2,1.5-0.6,2.1-1.1
+														c2.1-1.7,2-3.6-0.4-5c-1.5-0.9-1.8-2.5-0.8-3.8c0.6-0.9,1.3-1.7,1.9-2.6c0.3-0.5,0.5-0.7,1-0.1c1.2,1.4,2.3,3,3.2,4.7
+														c0.5,1,0.3,2,0.3,3.1c0,2.6,1.1,3.9,3.5,4.4C606.8,235.6,609.9,237.3,612.5,240z"></path>
+                                <path d="M613.5,262.5c-0.1,1.1-1.1,1.7-1.7,2.5c-1.8,2.4-3.8,0.9-5.8,0.6c-0.3-0.1-0.4-0.5-0.5-0.7
+														c-1-1.8-0.9-3.5,0.9-4.8c0.2-0.2,0.4-0.4,0.6-0.6c1.8-1.9,2.1-2,4.1-0.3c0.9,0.7,1.5,1.7,2.2,2.5
+														C613.5,262,613.5,262.3,613.5,262.5z"></path>
+                            </a>
+                            <a class="department" id="dep-972" data-num-dep="972">
+                                <title>972 - Martinique</title>
+                                <path d="M604.2,201.3c-2.5-1.1-5-2.1-7.7-2.4c-1.9-0.3-3.7-0.5-5.4,0.9c-1.3,1.1-1.4,1-2.4-0.5
+														c-1.2-1.9-2.2-3.9-2.2-6.4c0-0.9,0.3-1.3,1.2-1.3c2,0,4-0.2,6.1-0.3c0.5,0,0.9,0,1.3-0.4c-0.8-0.6-1.4-1.3-1.7-2.2
+														c-0.2-0.7-0.8-0.7-1.3-0.5c-1.7,0.7-3.2,0-4.8-0.3c-0.4-0.1-0.6-0.3-0.7-0.7c-0.3-1.3-1.2-1.6-2.3-1.8c-0.9-0.1-1.4-0.7-2-1.3
+														c-1.9-2.1-2.4-4.6-2.4-7.3c0-2.2-0.2-2.5-2.3-3.2c-0.9-0.3-1.4-0.7-1.6-1.5c-0.1-0.2-0.1-0.4-0.2-0.6c-1.6-2.2-0.5-4.1,0.5-6.1
+														c0.2-0.4,0.5-0.5,0.8-0.6c2.6-1.2,5.4-1,8.2-1c0.5,0,0.8,0.4,1.1,0.7c1.3,1,2.4,2.1,4.3,1.9c1-0.1,1.8,0.5,2.4,1.3
+														c1.3,1.8,2.8,3.5,4.2,5.3c0.5,0.7,1,1.1,1.8,0.4c0.2-0.2,0.5-0.3,0.7-0.3c1.9,0.4,3.4-0.7,4.8-1.7c0.8-0.6,1-0.3,1.3,0.4
+														c0.1,0.3,0.1,0.5,0.3,0.7c0.7,1,0.4,1.6-0.7,1.9c-1.3,0.4-1.1,1.7-1.5,2.7c-0.5-0.4-1-0.7-1.4-1.1c-0.7-0.8-1.2-0.5-1.8,0.1
+														c-0.3,0.3-0.5,0.6-0.4,0.9c0.1,0.4,0.6,0.2,0.8,0.3c0.4,0.3,1.5-0.2,1.4,0.8c-0.1,0.9,0.7,2.3-0.9,2.7c-0.5,0.1-0.8,0.4-0.6,1
+														c0.2,0.6,0.7,0.3,1,0.3c0.8,0,1.5-0.4,2.3-0.7c0.5-0.2,0.8-0.1,0.7,0.5c0,0.3,0.1,0.6,0,0.8c-0.8,1.5,0.1,2.3,1,3.3
+														c0.7,0.7,1.1,1.7,1.7,2.4c1.3,1.7,2.2,3.7,2.4,5.9c0,0.3-0.1,0.8,0.3,0.8c1.5,0,1,1,1.1,1.8c0.1,3.8-1.6,6.7-4.4,9
+														c-0.5,0.4-0.8,0.5-1.3,0c-0.1-0.1-0.3-0.3-0.4-0.4C603.2,203.7,603.2,203.7,604.2,201.3z M601.1,174.2c-1-0.3-1.8,0-2.5,0.6
+														c-0.7,0.5-1.2,0.4-1.7-0.2c-1.6-2.1-3.3-4.1-5-6.2c-0.5-0.6-1-1-1.8-0.9c-1.4,0-2.6-0.3-3.7-1.3c-0.6-0.5-1.1-1.2-1.9-1.1
+														c-2.1,0-4.3-0.3-6.4,0.6c-0.9,0.4-2.4,2.5-2.4,3.4c0.1,1.6,1.5,3.5,3,4c1,0.3,1.6,0.7,1.7,1.8c0.2,1.4,0.4,2.8,0.4,4.3
+														c0.1,2.6,2.1,5,4.5,5.6c0.5,0.1,1.2,0.1,1.4,0.8c0.4,1.4,1.4,1.6,2.6,1.9c1.2,0.3,2.2-0.2,3.3-0.4c0.5-0.1,0.9-0.2,1.1,0.4
+														c0.5,1.5,1.5,2.6,2.8,3.5c0.5,0.4,0.5,0.7-0.1,0.9c-1,0.4-2,0.8-3.1,0.8c-1.7,0-3.3,0.2-5,0.2c-0.7,0-0.8,0.3-0.8,0.9
+														c0.1,2,1,3.6,2.1,5.2c0.4,0.6,0.7,0,1-0.2c1-0.7,1.9-1.3,3.2-1.2c3.2,0.3,6.4,0.7,9.3,2.3c0.7,0.4,2,0.1,2.3,0.7
+														c0.3,0.7-0.5,1.5-0.8,2.3c-0.3,1,0.7,1.2,1.1,1.8c0.4,0.5,0.8,0.1,1.1-0.2c1.7-1.4,2.3-3.4,3.1-5.3c0.3-0.8,0.5-2.2-0.2-2.6
+														c-1-0.5-1-1.2-1-1.8c-0.2-3.5-2.6-5.8-4.4-8.5c-0.4-0.5-1.2-0.8-1.5-1.3c-0.4-0.7,0.8-1.1,0.6-1.9c-0.8,0.1-1.5,0.3-2.2,0.4
+														c-1.3,0.1-1.5-0.7-1.8-1.7c-0.3-1,0.1-1.5,1-1.7c0.4-0.1,0.9-0.3,0.8-0.9c0-0.7-0.6-0.5-1-0.6c-0.5-0.1-1.3,0-1.4-0.8
+														c0-0.8-0.4-1.6,0.5-2.2C600.2,175.1,600.6,174.6,601.1,174.2z M602,174.2c0.5,0.2,0.7,1.1,1.2,0.5c0.4-0.5,0.8-0.8,1.3-1.1
+														c0.3-0.2,0.8-0.3,0.5-0.8c-0.3-0.6-0.7-0.1-1,0.1C603.4,173.3,602.7,173.7,602,174.2z"></path>
+                                <path d="M601.1,174.2c-0.5,0.4-0.9,0.9-1.5,1.2c-0.9,0.6-0.6,1.5-0.5,2.2c0,0.8,0.8,0.6,1.4,0.8c0.4,0.1,0.9,0,1,0.6
+														c0,0.6-0.4,0.8-0.8,0.9c-1,0.2-1.3,0.7-1,1.7c0.3,1,0.5,1.8,1.8,1.7c0.8-0.1,1.5-0.3,2.2-0.4c0.1,0.8-1.1,1.2-0.6,1.9
+														c0.3,0.5,1.2,0.8,1.5,1.3c1.8,2.7,4.2,5,4.4,8.5c0,0.6,0.1,1.3,1,1.8c0.8,0.4,0.5,1.9,0.2,2.6c-0.8,1.9-1.4,3.9-3.1,5.3
+														c-0.3,0.3-0.7,0.7-1.1,0.2c-0.4-0.5-1.5-0.8-1.1-1.8c0.3-0.8,1.1-1.7,0.8-2.3c-0.3-0.7-1.6-0.3-2.3-0.7c-2.9-1.5-6.1-2-9.3-2.3
+														c-1.3-0.1-2.2,0.5-3.2,1.2c-0.3,0.2-0.6,0.8-1,0.2c-1-1.6-2-3.2-2.1-5.2c0-0.6,0.1-0.9,0.8-0.9c1.7,0,3.3-0.2,5-0.2
+														c1.1,0,2.1-0.5,3.1-0.8c0.6-0.2,0.7-0.6,0.1-0.9c-1.3-0.9-2.3-2-2.8-3.5c-0.2-0.6-0.6-0.5-1.1-0.4c-1.1,0.2-2.1,0.7-3.3,0.4
+														c-1.2-0.3-2.2-0.5-2.6-1.9c-0.2-0.7-0.9-0.7-1.4-0.8c-2.4-0.6-4.4-3.1-4.5-5.6c0-1.4-0.2-2.9-0.4-4.3c-0.1-1.1-0.7-1.5-1.7-1.8
+														c-1.6-0.5-3-2.4-3-4c-0.1-1,1.5-3.1,2.4-3.4c2.1-0.9,4.3-0.5,6.4-0.6c0.8,0,1.4,0.7,1.9,1.1c1.1,1,2.3,1.3,3.7,1.3
+														c0.8,0,1.3,0.3,1.8,0.9c1.6,2.1,3.3,4.1,5,6.2c0.5,0.7,1,0.8,1.7,0.2C599.4,174.2,600.2,173.9,601.1,174.2z">
+                                </path>
+                            </a>
+                            <a class="department" id="dep-974" data-num-dep="974">
+                                <title>974 - La Réunion</title>
+                                <path d="M612.1,363.1c-0.2,0.5-0.3,0.9-0.4,1.3c-1.3,3.1-2.2,6.3-2.1,9.8c0,0.8-0.4,1.1-1,1.2c-3,0.7-6,1.4-9,2
+														c-1.1,0.3-2.2-0.4-3.2-0.6c-2.6-0.6-5.2-1.4-7.8-2c-1.3-0.3-1.9-1.1-2.3-2.1c-0.8-1.8-2.3-2.2-4-2.2c-0.9,0-1.5-0.3-2.1-0.9
+														c-1-1-2-2.1-3.1-3.1c-0.5-0.5-0.5-0.8,0-1.3c0.4-0.4,1.1-0.9,0.9-1.5c-0.4-1.2-0.5-2.9-1.7-3.5c-1.7-0.9-2-2.2-1.9-3.9
+														c0-0.3,0-0.6,0-0.9c-0.1-2.2-0.1-2.3,2.1-2.4c0.9,0,1.3-0.3,1.1-1.2c-0.1-0.5,0-1.1-0.1-1.6c-0.3-2-0.3-2.1,1.6-2.3
+														c1.6-0.2,2.9-0.6,3.8-1.9c1.1-1.7,3-1.1,4.5-1.6c0.2-0.1,0.5,0,0.7-0.1c2-1,3.6-0.3,5.1,1.1c0.9,0.8,2.1,0.2,3.1,0.2
+														c0.3,0,0.8-0.3,0.9-0.1c1.8,1.7,4.9,0.5,6.4,2.8c0.4,0.6,1,1,0.6,1.8c-0.2,0.4-0.2,0.9-0.3,1.3c-0.2,0.9-0.2,1.6,0.6,2.3
+														c1.7,1.3,2.5,3.4,3.5,5.2c0.2,0.4,0.3,1,0.9,0.8c1.5-0.3,1.8,0.7,2.3,1.7C611.5,361.9,611.8,362.5,612.1,363.1z M599.4,376
+														c2.2-0.5,4.3-1,6.4-1.4c0.7-0.2,1.6-0.2,2.2-0.6c0.8-0.5,0.2-1.5,0.4-2.3c0-0.1,0.1-0.3,0.1-0.4c0.5-2.6,1-5.1,2-7.5
+														c0.6-1.4-0.5-3-2-3.1c-0.8,0-1-0.5-1.2-1c-1-1.8-1.7-3.8-3.4-5.2c-1.3-1-1.7-2.1-1.1-3.7c0.5-1.5-0.9-3.3-2.5-3.3
+														c-1.1,0-2.2,0.1-3.1-0.9c-0.3-0.3-0.7-0.2-1-0.1c-1.8,0.5-3.3,0.2-4.7-1.1c-0.5-0.5-1.1-0.8-1.8-0.6c-1.2,0.5-2.6,0.5-3.8,0.7
+														c-0.9,0.1-1.5,0.5-2.1,1.1c-0.7,0.6-1.1,1.5-2.1,1.8c-0.9,0.3-2.3-0.1-2.7,0.8c-0.4,0.8,0,1.9,0.1,2.9c0,0,0,0.1,0,0.1
+														c0.3,1.1-0.2,1.6-1.3,1.7c-2,0.3-2,0.3-1.9,2.3c0,0.7-0.3,1.6,0.5,2c1.9,0.9,2.3,2.8,3,4.4c0.4,0.8,0.5,1.5-0.3,2.2
+														c-0.2,0.2-0.5,0.5-0.4,0.9c0.3,1,3.4,3.6,4.4,3.5c2.3-0.3,3.8,0.7,4.7,2.7c0.4,0.8,1,1.4,2,1.6c1.9,0.4,3.7,0.9,5.6,1.4
+														C596.7,375.3,598.1,375.7,599.4,376z"></path>
+                                <path d="M599.4,376c-1.4-0.3-2.8-0.7-4.2-1.1c-1.9-0.5-3.7-1-5.6-1.4c-1-0.2-1.6-0.7-2-1.6c-0.9-2-2.4-3-4.7-2.7
+														c-1,0.1-4-2.5-4.4-3.5c-0.1-0.4,0.1-0.7,0.4-0.9c0.7-0.7,0.6-1.3,0.3-2.2c-0.7-1.7-1-3.5-3-4.4c-0.8-0.4-0.4-1.3-0.5-2
+														c-0.1-2-0.1-2.1,1.9-2.3c1.2-0.1,1.6-0.6,1.3-1.7c0,0,0-0.1,0-0.1c-0.1-1-0.5-2.1-0.1-2.9c0.4-0.8,1.8-0.5,2.7-0.8
+														c1-0.3,1.5-1.1,2.1-1.8c0.6-0.6,1.2-1,2.1-1.1c1.3-0.1,2.6-0.2,3.8-0.7c0.7-0.3,1.3,0.1,1.8,0.6c1.4,1.3,2.9,1.6,4.7,1.1
+														c0.3-0.1,0.8-0.2,1,0.1c0.8,1,2,0.9,3.1,0.9c1.6,0,3.1,1.8,2.5,3.3c-0.6,1.6-0.2,2.7,1.1,3.7c1.7,1.3,2.3,3.4,3.4,5.2
+														c0.3,0.5,0.5,1,1.2,1c1.5,0.1,2.6,1.7,2,3.1c-1,2.4-1.6,5-2,7.5c0,0.1-0.1,0.3-0.1,0.4c-0.2,0.8,0.4,1.8-0.4,2.3
+														c-0.6,0.4-1.5,0.4-2.2,0.6C603.7,375.1,601.6,375.5,599.4,376z"></path>
+                            </a>
+                            <a class="department" id="dep-973" data-num-dep="973">
+                                <title>973 - Guyane</title>
+                                <path d="M578.6,323.9c0.5-0.3,0.7-0.5,0.9-0.5c2.5-0.4,3.9-2,5-4.2c0.2-0.5,0.4-1,0.3-1.5c-0.2-2.2,0.2-4.3,1.3-6.3
+														c0.3-0.6,0.3-1.1-0.2-1.7c-1.6-2.2-3.2-4.4-4-7.1c-0.7-2.5-0.5-5-0.2-7.5c0.1-1.1,1.3-2.2,2.1-3.2c1.1-1.5,2.2-3.1,3.2-4.6
+														c0.4-0.6,0.8-0.9,1.5-0.5c1.5,0.7,3.1,1.1,4.5,2c1.1,0.7,2.5,0.8,3.8,0.8c1.9,0,3.6,0.3,5,1.9c2.2,2.3,4.7,4.3,7,6.5
+														c0.8,0.7,1.7,1.2,2.8,1.1c0.6-0.1,1,0.2,1.3,0.7c0.3,0.5,0.6,1,0.9,1.5c1.2,1.8,1.1,3.7-0.5,5.1c-3,2.8-4.5,6.6-6.7,9.9
+														c-0.8,1.1-1.4,2.3-2.1,3.4c-0.5,0.8-0.9,1.6-0.9,2.6c0,0.9-0.4,1.4-1.3,1.8c-4.1,2-8.4,1.3-12.7,1.1c-1.2,0-2.3,0.1-3.3,0.7
+														c-0.7,0.3-1.3,0.4-2,0.1C582.6,325.2,580.7,324.6,578.6,323.9z M582.1,323.8c1.6,0.5,3.4,1.6,5.3,0.3c0.2-0.1,0.4-0.1,0.7-0.1
+														c2.5,0,5.1-0.1,7.6,0.1c1.8,0.2,3.3-0.1,5-0.7c1.2-0.5,2.3-0.8,2.2-2.5c0-0.6,0.4-1.1,0.7-1.6c0.9-1.4,1.7-3,2.7-4.4
+														c2-3,3.4-6.5,6.1-9c1.9-1.8,1.8-3.9-0.2-5.6c-0.3-0.2-0.6-0.3-0.9-0.2c-1.1,0.1-2-0.4-2.8-1.1c-2.1-1.9-4.3-3.8-6.3-5.9
+														c-1.7-1.8-3.6-2.6-6.1-2.5c-0.9,0.1-1.9,0.2-2.6-0.3c-1.3-0.9-2.8-1.5-4.1-2.3c-0.7-0.4-1.1-0.4-1.6,0.3c-1.5,2.2-3,4.3-4.4,6.4
+														c-0.2,0.3-0.5,0.6-0.5,1.1c0,2.9-0.3,5.8,1.1,8.6c0.9,1.8,2.2,3.3,3.3,4.9c0.5,0.7,0.6,1.2,0.2,2c-1.1,2.1-1.3,4.4-1.5,6.7
+														C585.7,320.5,584.3,322.6,582.1,323.8z"></path>
+                                <path
+                                    d="M582.1,323.8c2.2-1.2,3.6-3.3,3.8-5.7c0.2-2.4,0.4-4.6,1.5-6.7c0.4-0.7,0.2-1.3-0.2-2
+														c-1.1-1.6-2.4-3.1-3.3-4.9c-1.4-2.8-1.1-5.7-1.1-8.6c0-0.4,0.2-0.8,0.5-1.1c1.5-2.1,3-4.3,4.4-6.4c0.5-0.7,0.9-0.7,1.6-0.3
+														c1.3,0.8,2.8,1.4,4.1,2.3c0.8,0.6,1.8,0.4,2.6,0.3c2.5-0.2,4.4,0.7,6.1,2.5c2,2.1,4.2,3.9,6.3,5.9c0.8,0.7,1.7,1.2,2.8,1.1
+														c0.3,0,0.6,0,0.9,0.2c1.9,1.7,2.1,3.8,0.2,5.6c-2.7,2.6-4.1,6-6.1,9c-0.9,1.4-1.8,2.9-2.7,4.4c-0.3,0.5-0.7,1-0.7,1.6
+														c0.1,1.7-1,2-2.2,2.5c-1.6,0.6-3.2,0.9-5,0.7c-2.5-0.2-5-0.1-7.6-0.1c-0.2,0-0.5,0-0.7,0.1C585.5,325.5,583.7,324.4,582.1,323.8z">
+                                </path>
+                            </a>
+                            <a class="department" id="dep-976" data-num-dep="976">
+                                <title>976 - Mayotte</title>
+                                <path d="M594.8,398.8c0.2,1.4,0.2,2.8,1.7,3.5c0.5,0.3,0.4,1.1,0.5,1.6c0.2,0.9,0.6,1.4,1.3,1.9
+														c0.6,0.4,1.1,0.5,1.8,0.3c3.2-1.2,7.8,1,8.8,4.1c0.3,0.9,0.2,1.9,0.3,2.8c0,0.5-0.3,0.6-0.8,0.7c-1.9,0.5-2.5,2.2-3.4,3.6
+														c-0.6,0.8,0.3,1.7,1,2.4c1.8,1.9,1.8,1.9,0.1,3.9c-0.4,0.5-0.7,0.9-0.4,1.6c0.5,1.1,0.3,1.9-1,2.4c-1.7,0.6-1.6,2.3-2.2,3.6
+														c-0.2,0.5,0.5,0.5,0.8,0.7c0.7,0.6,2.3,0.3,1.6,2c-0.5,1.2-1.6,1.8-2.9,1.6c-0.7-0.1-1.3,0.3-1.9,0.6c-0.8,0.4-1.5,0.7-2.2-0.1
+														c-0.1-0.1-0.2-0.2-0.3-0.2c-2.8,0-3.2-2.3-3.7-4.2c-0.5-2-1-3.9-2-5.6c-0.4-0.7-0.2-1,0.5-1.3c1.4-0.6,2.7,0,3.1,1.4
+														c0.2,0.7,2.2,1.6,2.7,1.2c0.5-0.4,0.3-0.9,0-1.3c-1.2-1.8-2.5-3.5-3.8-5.2c-0.6-0.8-0.7-1.3,0.2-1.8c0.6-0.3,0.8-0.7,0.3-1.5
+														c-1-1.5-1.1-3.3-0.8-5.1c0.2-1.2-0.4-1.3-1.2-1c-1.1,0.3-2.2,0.2-3.3,0.2c-1,0-2.3-1.3-2.3-2.4c0-0.8,0-1.6,0-2.4
+														c0.1-1.1,0.2-2.1,1.4-2.7c0.5-0.3,0.9-0.8,1.3-1.4C591.1,400.8,592.1,399.9,594.8,398.8z M592.9,425.7c1.3,2,1.7,4,2.1,6
+														c0.3,1.4,0.8,2.9,2.8,3.3c1,0.2,1.8,0.3,2.7-0.2c0.4-0.2,0.8-0.5,1.3-0.3c0.8,0.3,1.6,0.2,1.8-0.6c0.2-0.8-0.8-0.7-1.3-1.1
+														c-0.5-0.4-1.4-0.4-1.1-1.3c0.6-1.8,0.8-4,2.9-4.9c0.4-0.2,0.7-0.5,0.4-0.9c-0.9-1.4,0.1-2.3,0.9-3.1c0.7-0.7,0.7-1.2-0.1-1.8
+														c-1.1-0.9-2.3-2.1-1.6-3.6c0.7-1.7,1.8-3.4,3.5-4.3c0.6-0.3,0.7-0.5,0.6-1.2c-0.5-3.5-4.2-5.8-7.5-4.7c-2,0.7-3.8-0.4-4.4-2.5
+														c-0.2-0.6-0.1-1.4-0.7-1.8c-0.9-0.5-1.4-1.2-1.4-2.2c-0.6,0.1-0.9,0.5-1.4,0.8c-1.2,0.8-1.3,2.5-2.4,3.2c-2,1.2-1.7,3-1.7,4.8
+														c0,1,1,1.7,2,1.6c0.9-0.1,1.9-0.3,2.8-0.4c1.5-0.2,2,0.2,2.1,1.8c0,0.6-0.1,1.3-0.1,1.9c0.1,1.3,0.1,2.6,1.1,3.7
+														c0.6,0.7,0.6,1.2-0.2,1.7c-0.8,0.4-0.8,0.8-0.2,1.6c1.2,1.6,2.6,3.1,3.5,5c0.6,1.1,0.2,2.5-0.7,2.7c-1.5,0.4-3.7-0.7-4.2-2.2
+														C594.1,425.9,593.7,425.9,592.9,425.7z"></path>
+                                <path
+                                    d="M592.9,425.7c0.8,0.2,1.2,0.2,1.5,0.8c0.5,1.5,2.7,2.6,4.2,2.2c0.9-0.2,1.3-1.7,0.7-2.7
+														c-0.9-1.8-2.3-3.4-3.5-5c-0.6-0.7-0.5-1.1,0.2-1.6c0.8-0.5,0.9-1,0.2-1.7c-0.9-1-1-2.4-1.1-3.7c0-0.6,0.1-1.3,0.1-1.9
+														c0-1.6-0.5-2-2.1-1.8c-0.9,0.1-1.9,0.3-2.8,0.4c-0.9,0.1-1.9-0.6-2-1.6c-0.1-1.8-0.3-3.5,1.7-4.8c1.1-0.7,1.2-2.4,2.4-3.2
+														c0.4-0.3,0.7-0.7,1.4-0.8c0,1,0.5,1.7,1.4,2.2c0.7,0.4,0.6,1.2,0.7,1.8c0.6,2.1,2.4,3.1,4.4,2.5c3.3-1.1,6.9,1.2,7.5,4.7
+														c0.1,0.6,0,0.8-0.6,1.2c-1.7,0.9-2.7,2.6-3.5,4.3c-0.6,1.5,0.5,2.6,1.6,3.6c0.8,0.6,0.8,1.1,0.1,1.8c-0.8,0.8-1.8,1.7-0.9,3.1
+														c0.3,0.4,0,0.7-0.4,0.9c-2.1,0.9-2.3,3.1-2.9,4.9c-0.3,0.9,0.6,0.9,1.1,1.3c0.5,0.4,1.5,0.3,1.3,1.1c-0.2,0.8-1,0.9-1.8,0.6
+														c-0.5-0.2-0.9,0.1-1.3,0.3c-0.9,0.5-1.7,0.4-2.7,0.2c-2-0.4-2.5-1.9-2.8-3.3C594.6,429.7,594.2,427.7,592.9,425.7z">
+                                </path>
+                            </a>
+                        </g>
+                    </svg>
+                </div>
+                <div id="aside-content" class="col-lg-5">
+                    <div id="region-select" class="form-group">
+                        <label for="regions-list">Département :</label>
+                        <div class="row">
+                            <div class="col-9">
+                                <select name="departements" id="departements-list" class="form-control">
+                                    <option value="">
+                                        - Sélectionner un département -
+                                    </option>
+                                    <option value="01">Ain</option>
+                                    <option value="02">Aisne</option>
+                                    <option value="03">Allier</option>
+                                    <option value="04">Alpes-de-Haute-Provence</option>
+                                    <option value="05">Hautes-Alpes</option>
+                                    <option value="06">Alpes-Maritimes</option>
+                                    <option value="07">Ardèche</option>
+                                    <option value="08">Ardennes</option>
+                                    <option value="09">Ariège</option>
+                                    <option value="10">Aube</option>
+                                    <option value="11">Aude</option>
+                                    <option value="12">Aveyron</option>
+                                    <option value="13">Bouches-du-Rhône</option>
+                                    <option value="14">Calvados</option>
+                                    <option value="15">Cantal</option>
+                                    <option value="16">Charente</option>
+                                    <option value="17">Charente-Maritime</option>
+                                    <option value="18">Cher</option>
+                                    <option value="19">Corrèze</option>
+                                    <option value="2A">Corse-du-Sud</option>
+                                    <option value="2B">Haute-Corse</option>
+                                    <option value="21">Côte-d'Or</option>
+                                    <option value="22">Côtes-d'Armor</option>
+                                    <option value="23">Creuse</option>
+                                    <option value="24">Dordogne</option>
+                                    <option value="25">Doubs</option>
+                                    <option value="26">Drôme</option>
+                                    <option value="27">Eure</option>
+                                    <option value="28">Eure-et-Loir</option>
+                                    <option value="29">Finistère</option>
+                                    <option value="30">Gard</option>
+                                    <option value="31">Haute-Garonne</option>
+                                    <option value="32">Gers</option>
+                                    <option value="33">Gironde</option>
+                                    <option value="34">Hérault</option>
+                                    <option value="35">Ille-et-Vilaine</option>
+                                    <option value="36">Indre</option>
+                                    <option value="37">Indre-et-Loire</option>
+                                    <option value="38">Isère</option>
+                                    <option value="39">Jura</option>
+                                    <option value="40">Landes</option>
+                                    <option value="41">Loir-et-Cher</option>
+                                    <option value="42A">Loire (A)</option>
+                                    <option value="42B">Loire (B)</option>
+                                    <option value="43">Haute-Loire</option>
+                                    <option value="44">Loire-Atlantique</option>
+                                    <option value="45">Loiret</option>
+                                    <option value="46">Lot</option>
+                                    <option value="47">Lot-et-Garonne</option>
+                                    <option value="48">Lozère</option>
+                                    <option value="49">Maine-et-Loire</option>
+                                    <option value="50">Manche</option>
+                                    <option value="51">Marne</option>
+                                    <option value="52">Haute-Marne</option>
+                                    <option value="53">Mayenne</option>
+                                    <option value="54">Meurthe-et-Moselle</option>
+                                    <option value="55">Meuse</option>
+                                    <option value="56">Morbihan</option>
+                                    <option value="57">Moselle</option>
+                                    <option value="58">Nièvre</option>
+                                    <option value="59">Nord</option>
+                                    <option value="60">Oise</option>
+                                    <option value="61">Orne</option>
+                                    <option value="62">Pas-de-Calais</option>
+                                    <option value="63">Puy-de-Dôme</option>
+                                    <option value="64A">Pyrénées-Atlantiques (A)</option>
+                                    <option value="64B">Pyrénées-Atlantiques (B)</option>
+                                    <option value="65">Hautes-Pyrénées</option>
+                                    <option value="66">Pyrénées-Orientales</option>
+                                    <option value="67">Bas-Rhin</option>
+                                    <option value="68">Haut-Rhin</option>
+                                    <option value="69">Rhône</option>
+                                    <option value="70">Haute-Saône</option>
+                                    <option value="71">Saône-et-Loire</option>
+                                    <option value="72">Sarthe</option>
+                                    <option value="73">Savoie</option>
+                                    <option value="74">Haute-Savoie</option>
+                                    <option value="75">Paris</option>
+                                    <option value="76A">Seine-Maritime (A)</option>
+                                    <option value="76B">Seine-Maritime (B)</option>
+                                    <option value="77">Seine-et-Marne</option>
+                                    <option value="78">Yvelines</option>
+                                    <option value="79">Deux-Sèvres</option>
+                                    <option value="80">Somme</option>
+                                    <option value="81">Tarn</option>
+                                    <option value="82">Tarn-et-Garonne</option>
+                                    <option value="83">Var</option>
+                                    <option value="84">Vaucluse</option>
+                                    <option value="85">Vendée</option>
+                                    <option value="86">Vienne</option>
+                                    <option value="87">Haute-Vienne</option>
+                                    <option value="88">Vosges</option>
+                                    <option value="89">Yonne</option>
+                                    <option value="90">Territoire de Belfort</option>
+                                    <option value="91">Essonne</option>
+                                    <option value="92">Hauts-de-Seine</option>
+                                    <option value="93">Seine-Saint-Denis</option>
+                                    <option value="94">Val-de-Marne</option>
+                                    <option value="95">Val-d'Oise</option>
+                                    <option value="971">Guadeloupe</option>
+                                    <option value="972">Martinique</option>
+                                    <option value="973">Guyane</option>
+                                    <option value="974">La Réunion</option>
+                                    <option value="976">Mayotte</option>
+                                </select>
+                            </div>
+                            <div class="col-3 pl-0">
+                                <button type="submit" id="dep-sel-btn" class="btn btn--plain btn--primary">
+                                    OK
+                                </button>
                             </div>
                         </div>
                     </div>
-                </div>
-
-                <!-- Tableau 15-15 -->
-                <table id="avancement15-15">
-                    <caption>Avancement des travaux 15-15</caption>
-                    <thead>
-                        <tr>
-                            <th class="col-auto">Cas d'usage </th>
-                            <th class="col-4">En production </th>
-                            <th class="col-4">Tests ANS-Editeur validés</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-
-                        <tr>
-                            <th scope="row">Partage de dossier</th>
-                            <td>Appligos (SAMU 78)
-                                <br>Scriptal (SAMU 77, SAMU 95)
-                            </td>
-                            <td> BISOM
-                                <br>Exos
-                                <br>Nexpublica
-                                <br>SICAP
-                            </td>
-                        </tr>
-                        <tr>
-                            <th scope="row">Partage de ressources <br>(moyens)</th>
-                            <td>Appligos (SAMU 78)
-                                <br>Scriptal (SAMU 77, SAMU 95)
-                            </td>
-                            <td> BISOM
-                            </td>
-                        </tr>
-                        <tr>
-                            <th scope="row">Echanges AMU-SNP</th>
-                            <td>Appligos (SAS 41)
-                                <br>Scriptal (SAS 18)
-                            </td>
-                            <td> N/A </td>
-                        </tr>
-                    </tbody>
-                </table>
-
-            </div>
-
-
-            <!-- Titre 15-NexSIS -->
-            <div class="bg-white" id="15-nexsis">
-                <div class="container paragraph-space paragraph--title-text text-center pt-2 pb-1">
-                    <h1>15-NexSIS</h1>
-                </div>
-            </div>
-            <!-- Bannière Enjeux 15-18 -->
-            <div class="container paragraph-space">
-                <div class="row">
-                    <div class="col-md-8 mb-3">
-                        <h2>Les enjeux du 15-NexSIS </h2>
-                        <div class="wysiwyg mb-3">
-                            <ul>
-                                <li>Rendre les LRM interopérables avec le système d’information des pompiers et
-                                    développer de nouvelles fonctionnalités grâce à l’échange de ces nouveaux flux de
-                                    données.
-                                </li>
-                                <li>Permettre l’interfaçage de NexSIS, le futur système d’information et de commandement
-                                    unifié des services d’incendie et de secours, avec n’importe quel SAMU sans
-                                    développement d’un lien spécifique.
-                                </li>
-                                <li>Garantir des échanges de données sécurisés via un cadre d’interopérabilité
-                                    coconstruit.
-                                </li>
-                            </ul>
-                        </div>
-
+                    <div id="department-infos"
+                        class="rounded-md top-left-radius-0 highlighted-text-card bg-primary text-white mt-5 px-3 py-4 d-none">
+                        <h2 class="h4" id="department-title"></h2>
                         <div class="paragraph--lien">
-                            <a href="/pages/accompagnement.html" class="btn btn--style1 btn--white">Ressources
-                                éditeurs</a>
-                        </div>
-                    </div>
-                    <div class="col-md-4 order-md-first">
-                        <div class="rounded-md top-left-radius-0 bg-primary text-white px-2 py-4">
-                            <div class="wysiwyg">
-                                <h3>Les pilotes</h3>
-                                <ul>
-                                    <li>NexSIS - SAMU 09 (BISOM)</li>
-                                    <li>NexSIS - SAMU 44 (Nexpublica)</li>
-                                    <li>NexSIS - SAMU 50 (RRAMU)</li>
-                                    <li>NexSIS - SAMU 78 (Appligos)</li>
-                                    <li>NexSIS - SAMU 95 (Scriptal)</li>
-                                    <li>NexSIS - SAMU 37 (Exos)</li>
-                                </ul>
-                            </div>
+                            <a href="#" class="btn--white btn--icon-before">
+                                <svg class="svg-icon svg-angle-right" aria-hidden="true" focusable="false">
+                                    <use xlink:href="/svg-icons/icon-sprite.svg#angle-right"></use>
+                                </svg>
+                            </a>
                         </div>
                     </div>
                 </div>
-
-                <!-- Tableau 15-Nexsis -->
-                <table id="avancement15-Nexsis">
-                    <caption>Avancement des travaux 15-Nexsis</caption>
-                    <thead>
-                        <tr>
-                            <th class="col-auto">Cas d'usage </th>
-                            <th class="col-4">En production </th>
-                            <th class="col-4">Tests ANS-Editeur validés</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-
-                        <tr>
-                            <th scope="row">Partage de dossier</th>
-                            <td>Appligos (SAMU 07)
-                                <br>Nexpublica (SAMU 01, SAMU 21, SAMU 44)
-                            </td> 
-                            <td>BISOM
-                                <br>Exos
-                                <br>Scriptal
-                            </td>
-                        </tr>
-
-
-                    </tbody>
-                </table>
             </div>
 
-            <!-- Titre 15-SMUR/RPIS -->
-            <div class="bg-white" id="15-smur">
+            <!-- Titre Editeurs -->
+            <div class="bg-white" id="editeurs">
                 <div class="container paragraph-space paragraph--title-text text-center pt-2 pb-1">
-                    <h1>15-SMUR/RPIS</h1>
+                    <h1>Les éditeurs de LRM</h1>
                 </div>
             </div>
 
-            <!-- Bannière Enjeux 15-SMUR -->
             <div class="container paragraph-space">
-                <div class="row">
-                    <div class="col-md-7 mb-3">
-                        <h2>Les enjeux du 15-SMUR/RPIS </h2>
-                        <div class="wysiwyg mb-3">
-                            <ul>
-                                <li>Permettre aux LRM et tablettes SMUR d'échanger des données opérationnelles, telles
-                                    que les informations dossier, la géolocalisation des SMUR ou encore les états de
-                                    situation des SMUR.
-                                </li>
-                                <li>Remonter les données RPIS vers les ORU ou les infocentres régionaux depuis les
-                                    tablettes SMUR, en vue de l'arrêté sur le RPIS à venir, avec une application pour
-                                    2025.
-                                </li>
-                                <li> Echanger des dossiers complets vers les partenaires des SMUR (infocentres
-                                    régionaux, archives SMUR, établissements de santé receveurs).
-                                </li>
-                            </ul>
-                        </div>
 
-                        <div class="paragraph--lien">
-                            <a href="/pages/accompagnement.html" class="btn btn--style1 btn--white">Ressources
-                                éditeurs</a>
-                        </div>
-                    </div>
-                    <div class="col-md-5 order-md-last">
-                        <div class="rounded-md top-left-radius-0 bg-primary text-white px-2 py-4">
-                            <div class="wysiwyg">
-                                <h3>Les pilotes</h3>
-                                <ul>
-                                    <li>BISOM : SAMU 85 (Nexpublica), SAMU 73 (Appligos)</li>
-                                    <li>Exos : SAMU 80 (Exos) </li>
-                                    <li>Nomadeec : SAMU 21-58 et 86 (Nexpublica) </li>
-                                    <li>Parsys : SAMU 94 (Nexpublica), SAMU 95 (Scriptal)</li>
-                                    <li>SMUR-t@b : SAMU 55 (Exos), SAMU 68 (Appligos), SAMU 77 (Scriptal)</li>
-                                    <li>Tildev : SAMU 35 (Nexpublica)</li>
-                                </ul>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- Tableau 15-SMUR -->
-                <table id="avancement15-Nexsis">
-                    <caption>Avancement des travaux 15-SMUR</caption>
+                <!-- Tableau éditeurs -->
+                <table id="table-editeurs">
+                    <caption>Statut des éditeurs de logiciel LRM</caption>
                     <thead>
                         <tr>
-                            <th class="col-auto">Cas d'usage </th>
-                            <th class="col-4">En production </th>
-                            <th class="col-4">Tests ANS-Editeur validés</th>
+                            <th class="col-auto pl-1">Périmètre</th>
+                            <th class="col-auto">Appligos</th>
+                            <th class="col-auto">BISOM</th>
+                            <th class="col-auto">Exos</th>
+                            <th class="col-auto">Nexpublica</th>
+                            <th class="col-auto">RRAMU</th>
+                            <th class="col-auto">Scriptal</th>
                         </tr>
                     </thead>
                     <tbody>
 
                         <tr>
-                            <th scope="row">Partage de dossier</th>
-                            <td>
-                            </td> 
-                            <td>Parsys
-                                <br>SMUR-t@b
-                                <br>Tildev
+                            <th class="pl-1" scope="row">
+                                <p class="m-teaser__type rounded-lg text-uppercase bg-primary text-white">15-15</p>
+                            </th>
+                            <td><span class="active" style="padding: 2px 8px; border-radius: 3px;"> <svg
+                                        class="svg-icon svg-valid" style="color:#368E6E;" aria-hidden="true"
+                                        focusable="false">
+                                        <use xlink:href="/svg-icons/icon-sprite.svg#valid"></use>
+                                    </svg>
+                                    En production</span></td>
+
+                            <td>                                <span class="test" style="padding: 2px 8px; margin-right: 8px; border-radius: 3px;">
+                                    <svg class="svg-icon svg-play" aria-hidden="true" focusable="false">
+                                        <use xlink:href="/svg-icons/icon-sprite.svg#play"></use>
+                                    </svg> Tests ANS validés</span>
                             </td>
+                            <td> <span class="dev" style="padding: 2px 8px; margin-right: 8px; border-radius: 3px;">
+                                    <svg class="svg-icon svg-time" aria-hidden="true" focusable="false">
+                                        <use xlink:href="/svg-icons/icon-sprite.svg#time"></use>
+                                    </svg>
+                                    <span>En développement</span>
+                                </span>
+                            </td>
+                            <td> <span class="dev" style="padding: 2px 8px; margin-right: 8px; border-radius: 3px;">
+                                    <svg class="svg-icon svg-time" aria-hidden="true" focusable="false">
+                                        <use xlink:href="/svg-icons/icon-sprite.svg#time"></use>
+                                    </svg>
+                                    <span>En développement</span>
+                                </span>
+                            </td>
+                            <td> <span class="dev" style="padding: 2px 8px; margin-right: 8px; border-radius: 3px;">
+                                    <svg class="svg-icon svg-time" aria-hidden="true" focusable="false">
+                                        <use xlink:href="/svg-icons/icon-sprite.svg#time"></use>
+                                    </svg>
+                                    <span>En développement</span>
+                                </span>
+                            </td>
+                            <td><span class="active" style="padding: 2px 8px; border-radius: 3px;"> <svg
+                                        class="svg-icon svg-valid" style="color:#368E6E;" aria-hidden="true"
+                                        focusable="false">
+                                        <use xlink:href="/svg-icons/icon-sprite.svg#valid"></use>
+                                    </svg>
+                                    En production</span></td>
+
                         </tr>
-
-
+                        <tr>
+                            <th class="pl-1" scope="row">
+                                <p class="m-teaser__type rounded-lg text-uppercase bg-primary text-white">15-NexSIS</p>
+                            </th>
+                            <td><span class="active" style="padding: 2px 8px; border-radius: 3px;"> <svg
+                                        class="svg-icon svg-valid" style="color:#368E6E;" aria-hidden="true"
+                                        focusable="false">
+                                        <use xlink:href="/svg-icons/icon-sprite.svg#valid"></use>
+                                    </svg>
+                                    En production</span></td>
+                            <td>                                <span class="test" style="padding: 2px 8px; margin-right: 8px; border-radius: 3px;">
+                                    <svg class="svg-icon svg-play" aria-hidden="true" focusable="false">
+                                        <use xlink:href="/svg-icons/icon-sprite.svg#play"></use>
+                                    </svg> Tests ANS validés</span>
+                            </td>
+                            <td> <span class="dev" style="padding: 2px 8px; margin-right: 8px; border-radius: 3px;">
+                                    <svg class="svg-icon svg-time" aria-hidden="true" focusable="false">
+                                        <use xlink:href="/svg-icons/icon-sprite.svg#time"></use>
+                                    </svg>
+                                    <span>En développement</span>
+                                </span>
+                            </td>
+                            <td> <span class="dev" style="padding: 2px 8px; margin-right: 8px; border-radius: 3px;">
+                                    <svg class="svg-icon svg-time" aria-hidden="true" focusable="false">
+                                        <use xlink:href="/svg-icons/icon-sprite.svg#time"></use>
+                                    </svg>
+                                    <span>En développement</span>
+                                </span>
+                            </td>
+                            <td> <span class="dev" style="padding: 2px 8px; margin-right: 8px; border-radius: 3px;">
+                                    <svg class="svg-icon svg-time" aria-hidden="true" focusable="false">
+                                        <use xlink:href="/svg-icons/icon-sprite.svg#time"></use>
+                                    </svg>
+                                    <span>En développement</span>
+                                </span>
+                            </td>
+                            <td><span class="active" style="padding: 2px 8px; border-radius: 3px;"> <svg
+                                        class="svg-icon svg-valid" style="color:#368E6E;" aria-hidden="true"
+                                        focusable="false">
+                                        <use xlink:href="/svg-icons/icon-sprite.svg#valid"></use>
+                                    </svg>
+                                    En production</span></td>
+                        </tr>
                     </tbody>
                 </table>
+
+                <div class="o-paragraph--mixed-push__teasers mt-4">
+                    <div class="o-paragraph--mixed-push__slider col--eq-height">
+
+                        <article class="m-teaser--service mb-3 tns-item tns-slide-active" id="tns1-item0">
+                            <div
+                                class="bg-gray-700 text-white rounded-md top-left-radius-0 text-center py-4 px-3">
+                                <h3 class="m-teaser__title h4">15-SMUR</h3>
+
+                                <div class="wysiwyg mb-3">
+                                    <p>Le lien est prêt pour une implémentation par les éditeurs de LRM et de tablettes</p>
+                                    <p>Le premier déploiement dans un SAMU est prévu en septembre 2026</p>
+                                </div>
+
+                                <svg class="svg-icon svg-arrow-right" aria-hidden="true" focusable="false">
+                                    <use xlink:href="svg-icons/icon-sprite.svg#arrow-right"></use>
+                                </svg>
+                            </div>
+                        </article>
+                        <article class="m-teaser--service mb-3 tns-item tns-slide-active" id="tns1-item0">
+                            <div
+                                class="bg-gray-700 text-white rounded-md top-left-radius-0 text-center py-4 px-3">
+                                <h3 class="m-teaser__title h4">15-SICAP</h3>
+
+                                <div class="wysiwyg mb-3">
+                                    <p>L'identification des sites pilotes et l'implémentation par les éditeurs de LRM est en cours</p>
+                                    <p>Le premier déploiement dans un SAMU est prévu en septembre 2026</p>
+                                </div>
+
+                                <svg class="svg-icon svg-arrow-right" aria-hidden="true" focusable="false">
+                                    <use xlink:href="svg-icons/icon-sprite.svg#arrow-right"></use>
+                                </svg>
+                            </div>
+                        </article>
+                        <article class="m-teaser--service mb-3 tns-item tns-slide-active" id="tns1-item0">
+                            <div
+                                class="bg-gray-700 text-white rounded-md top-left-radius-0 text-center py-4 px-3">
+                                <h3 class="m-teaser__title h4">15-Portail SI-SAMU</h3>
+
+                                <div class="wysiwyg mb-3">
+                                    <p>Le premier jalon fonctionnel identifié est le partage des dossiers du portail SI-SAMU vers le 15</p>
+                                    <p>Le raccordement du Portail SI-SAMU au Hub Santé est prévu en septembre</p>
+                                </div>
+
+                                <svg class="svg-icon svg-arrow-right" aria-hidden="true" focusable="false">
+                                    <use xlink:href="svg-icons/icon-sprite.svg#arrow-right"></use>
+                                </svg>
+                            </div>
+                        </article>
+                    </div>
+                </div>
+
             </div>
+
             <script type="text/javascript" src="/script/jquery-3.5.1.min.js"></script>
             <script type="text/javascript" src="/script/vendor.js"></script>
             <script type="text/javascript" src="/script/app.js"></script>
             <script type="text/javascript" src="/script/tiny-slider.js"></script>
             <script type="text/javascript" src="/script/bloc-o-remontees-diverses.js"></script>
             <script type="text/javascript" src="/script/bloc-global-sliders.js"></script>
+            <script type="text/javascript" src="/script/map.js"></script>
 </body>
 
 <!-- Bandeau bas -->
@@ -633,12 +1738,6 @@
                                 </svg>Documentation</a>
                         </li>
                         <li class="footer-list__item footer-list__item--hasIcon">
-                            <a href="/pages/webinaires.html">
-                                <svg class="svg-icon svg-angle-right" aria-hidden="true" focusable="false">
-                                    <use xlink:href="/svg-icons/icon-sprite.svg#angle-right"></use>
-                                </svg>Webinaires</a>
-                        </li>
-                        <li class="footer-list__item footer-list__item--hasIcon">
                             <a href="/pages/contacts.html">
                                 <svg class="svg-icon svg-angle-right" aria-hidden="true" focusable="false">
                                     <use xlink:href="/svg-icons/icon-sprite.svg#angle-right"></use>
@@ -692,7 +1791,5 @@
         </div>
     </div>
 </footer>
-
-
 
 </html>

--- a/web/landing/pages/travaux.html
+++ b/web/landing/pages/travaux.html
@@ -1616,7 +1616,7 @@
                                 <div class="wysiwyg mb-3">
                                     <p>Le premier jalon fonctionnel identifié est le partage des dossiers du portail
                                         SI-SAMU vers le 15</p>
-                                    <p>Le raccordement du Portail SI-SAMU au Hub Santé est prévu en septembre</p>
+                                    <p>Le raccordement du Portail SI-SAMU au Hub Santé est prévu en septembre 2026</p>
                                 </div>
 
                                 <svg class="svg-icon svg-arrow-right" aria-hidden="true" focusable="false">

--- a/web/landing/pages/travaux.html
+++ b/web/landing/pages/travaux.html
@@ -264,7 +264,8 @@
                         15-15 </a>
 
 
-                    <a href="/resources/Liens/Lien_15-NexSiS.pdf" class="btn btn--style1 btn--white mt-1" target="_blank">
+                    <a href="/resources/Liens/Lien_15-NexSiS.pdf" class="btn btn--style1 btn--white mt-1"
+                        target="_blank">
                         15-NexSIS </a>
 
 
@@ -1524,9 +1525,8 @@
                                     <span>En développement</span>
                                 </span>
                             </td>
-                            <td><span class="active"> <svg
-                                        class="svg-icon svg-valid" style="color:#368E6E;" aria-hidden="true"
-                                        focusable="false">
+                            <td><span class="active"> <svg class="svg-icon svg-valid" style="color:#368E6E;"
+                                        aria-hidden="true" focusable="false">
                                         <use xlink:href="/svg-icons/icon-sprite.svg#valid"></use>
                                     </svg>
                                     En production</span></td>
@@ -1536,9 +1536,8 @@
                             <th class="pl-1" scope="row">
                                 <p class="m-teaser__type rounded-lg text-uppercase bg-primary text-white">15-NexSIS</p>
                             </th>
-                            <td><span class="active"> <svg
-                                        class="svg-icon svg-valid" style="color:#368E6E;" aria-hidden="true"
-                                        focusable="false">
+                            <td><span class="active"> <svg class="svg-icon svg-valid" style="color:#368E6E;"
+                                        aria-hidden="true" focusable="false">
                                         <use xlink:href="/svg-icons/icon-sprite.svg#valid"></use>
                                     </svg>
                                     En production</span></td>
@@ -1568,9 +1567,8 @@
                                     <span>En développement</span>
                                 </span>
                             </td>
-                            <td><span class="active"> <svg
-                                        class="svg-icon svg-valid" style="color:#368E6E;" aria-hidden="true"
-                                        focusable="false">
+                            <td><span class="active"> <svg class="svg-icon svg-valid" style="color:#368E6E;"
+                                        aria-hidden="true" focusable="false">
                                         <use xlink:href="/svg-icons/icon-sprite.svg#valid"></use>
                                     </svg>
                                     En production</span></td>

--- a/web/landing/script/map.js
+++ b/web/landing/script/map.js
@@ -1,0 +1,74 @@
+document.getElementById("div-map").addEventListener("click", (e) => {
+    const dep = e.target.closest(".department");
+    if (!dep) return;
+    document.getElementById("departements-list").value = dep.dataset.numDep;
+    onDepartmentSelected(dep);
+});
+
+document.getElementById("dep-sel-btn").addEventListener("click", () => {
+    const selectedDepValue = document.getElementById("departements-list").value;
+    if (selectedDepValue === "") {
+        unselectDepartment();
+        hideInfoSelectedDepartment();
+    } else {
+        const dep = document.querySelector(`[data-num-dep="${selectedDepValue}"]`);
+        onDepartmentSelected(dep);
+    }
+});
+
+function onDepartmentSelected(dep) {
+    unselectDepartment();
+    document
+        .querySelectorAll(`.department[data-num-dep='${dep.dataset.numDep}']`)
+        .forEach((d) => d.classList.add("selected"));
+    renderDepartmentInfo(dep);
+}
+
+function unselectDepartment() {
+    document
+        .querySelectorAll(".department.selected")
+        .forEach((d) => d.classList.remove("selected"));
+}
+
+function hideInfoSelectedDepartment() {
+    const divInfo = document.getElementById("department-infos");
+    if (divInfo.classList.contains("d-block")) {
+        divInfo.classList.replace("d-block", "d-none");
+    }
+}
+
+function renderDepartmentInfo(dep) {
+    const divInfo = document.getElementById("department-infos");
+    divInfo.innerHTML = "";
+    if (divInfo.classList.contains("d-none")) {
+        divInfo.classList.replace("d-none", "d-block");
+    }
+
+    // Title
+    divInfo.appendChild(createTitleH2(dep));
+
+    // Content
+    if (!dep.classList.contains("prod")) {
+        divInfo.style.backgroundColor = "var(--gray-500)";
+        divInfo.appendChild(
+            createParagraph(
+                "Aucune information disponible pour ce département en environnement de production.",
+            ),
+        );
+    } else {
+        divInfo.style.backgroundColor = "var(--primary)";
+        divInfo.appendChild(createParagraph(dep.dataset.lien));
+    }
+}
+
+function createTitleH2(dep) {
+    const title = document.createElement("h2");
+    title.innerText = dep.querySelector("title").innerHTML;
+    return title;
+}
+
+function createParagraph(text) {
+    const p = document.createElement("p");
+    p.innerText = text;
+    return p;
+}

--- a/web/landing/style.css
+++ b/web/landing/style.css
@@ -121,25 +121,31 @@ html {
  
  /* Tableau des éditeurs */
 
-/* Décommissionnée */
 #table-editeurs td {
   padding-left: 0.8rem;
   padding-right: 0.8rem;
 }
 
+/* Tests ANS validés */
 #table-editeurs .test {
   text-align: center;
   background-color: #FFF2F9;
+  padding: 2px 6px; 
+  border-radius: 3px;
 }
 
-/* Active */
+/* En production */
 #table-editeurs .active {
   text-align: center;
   background-color: #f0f6e4 !important;
+  padding: 2px 6px; 
+  border-radius: 3px;
 }
 
-/* Fin de vie planifiée */
+/* En développement */
 #table-editeurs .dev {
   text-align: center;
   background-color: #fdf3e3 !important;
+  padding: 2px 6px; 
+  border-radius: 3px;
 }

--- a/web/landing/style.css
+++ b/web/landing/style.css
@@ -86,3 +86,60 @@ html {
     text-align: center;
     background-color: #fdf3e3 !important;
 }
+
+ 
+/* Map */
+#div-map .department {
+  fill: var(--gray-400);
+  stroke: var(--white);
+  cursor: pointer;
+  stroke-width: 0.6;
+}
+ 
+#div-map .department:hover {
+  fill: var(--gray-500);
+  cursor: "pointer";
+}
+ 
+#div-map .department.selected {
+  fill: var(--gray-500);
+  transition: fill 0.3s ease;
+}
+ 
+#div-map .department.prod {
+  fill: var(--primary);
+}
+ 
+#div-map .department.prod:hover {
+  fill: var(--primary-darker);
+}
+ 
+#div-map .department.prod.selected {
+  fill: var(--primary-darker);
+  transition: fill 0.3s ease;
+}
+ 
+ /* Tableau des éditeurs */
+
+/* Décommissionnée */
+#table-editeurs td {
+  padding-left: 0.8rem;
+  padding-right: 0.8rem;
+}
+
+#table-editeurs .test {
+  text-align: center;
+  background-color: #FFF2F9;
+}
+
+/* Active */
+#table-editeurs .active {
+  text-align: center;
+  background-color: #f0f6e4 !important;
+}
+
+/* Fin de vie planifiée */
+#table-editeurs .dev {
+  text-align: center;
+  background-color: #fdf3e3 !important;
+}


### PR DESCRIPTION
## 🔎 Détails

- Ajout d'un bandeau gris avec les liens disponibles : 1 fiche PDF par lien
- Ajout d'une carte de France avec les SAMU raccordés en PRODUCTION
- Ajout d'un tableau avec le statut de chaque éditeur
- Mise à jour du menu principal et du footer : nouvelle page "Actualités" et suppression "Les RDV du Hub" et "Le Hub en replay"

## 📸 Captures d'écran

| Avant | Après |
| ----- | ----- |
| <img alt="image" src="https://github.com/user-attachments/assets/d97cda39-7956-4788-b8db-16e56249c541" /> | <img alt="image" src="https://github.com/user-attachments/assets/3dcd83c4-ba42-4bd6-ad9a-48ab0831bd97" /> |