### PR TITLE
Correction des vulnerabilité applicatives sur le dispatcher

### DIFF
--- a/.github/workflows/dispatcher-build.yaml
+++ b/.github/workflows/dispatcher-build.yaml
@@ -65,6 +65,12 @@ jobs:
         run: chmod +x gradlew
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hardened Images
+        uses: docker/login-action@v3
+        with:
+          registry: dhi.io
+          username: ${{ secrets.DHI_USERNAME }}
+          password: ${{ secrets.DHI_PASSWORD }}
       - name: Login to Container Registry
         uses: docker/login-action@v3
         with:

--- a/hub/dispatcher/build.gradle
+++ b/hub/dispatcher/build.gradle
@@ -21,9 +21,9 @@ group = 'com.hubsante'
 ext {
     modelVersion = project.hasProperty('modelVersion') ? project.getProperty('modelVersion') : '3.3.2'
     // Pin transitive libs ahead of the Spring Boot 4.0.6 BOM to clear remaining CVEs
-    set('tomcat.version', '11.0.22')
-    set('netty.version', '4.2.13.Final')
-    set('jackson-bom.version', '3.1.1')
+    set('tomcat.version', libs.versions.tomcat.get())
+    set('netty.version', libs.versions.netty.get())
+    set('jackson-bom.version', libs.versions.jacksonBom.get())
 }
 
 java {

--- a/hub/dispatcher/build.gradle
+++ b/hub/dispatcher/build.gradle
@@ -1,3 +1,12 @@
+// Docker Hardened Images (dhi.io) ship layers compressed with Zstandard.
+// Jib relies on Apache Commons Compress, which needs zstd-jni on the build
+// classpath to read those layers. Without it: "Zstandard compression is not available".
+buildscript {
+    dependencies {
+        classpath 'com.github.luben:zstd-jni:1.5.6-9'
+    }
+}
+
 plugins {
     id 'java'
     alias(libs.plugins.spring.boot)

--- a/hub/dispatcher/build.gradle
+++ b/hub/dispatcher/build.gradle
@@ -11,6 +11,10 @@ group = 'com.hubsante'
 
 ext {
     modelVersion = project.hasProperty('modelVersion') ? project.getProperty('modelVersion') : '3.3.2'
+    // Pin transitive libs ahead of the Spring Boot 4.0.6 BOM to clear remaining CVEs
+    set('tomcat.version', '11.0.22')
+    set('netty.version', '4.2.13.Final')
+    set('jackson-bom.version', '3.1.1')
 }
 
 java {

--- a/hub/dispatcher/gradle/jib.gradle
+++ b/hub/dispatcher/gradle/jib.gradle
@@ -1,6 +1,6 @@
 jib {
     from {
-        image 'eclipse-temurin:21-jre'
+        image 'dhi.io/eclipse-temurin:21-alpine3.23'
     }
     to {
         image "ghcr.io/${System.getenv('GITHUB_REPOSITORY_OWNER')}/dispatcher"

--- a/hub/dispatcher/gradle/libs.versions.toml
+++ b/hub/dispatcher/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-springBoot = "4.0.3"
+springBoot = "4.0.6"
 testcontainers = "1.21.4"
 jsonSchemaValidator = "1.0.87"
 logstashEncoder = "9.0"

--- a/hub/dispatcher/gradle/libs.versions.toml
+++ b/hub/dispatcher/gradle/libs.versions.toml
@@ -9,6 +9,9 @@ orgJson = "20231013"
 googleJavaFormat = "1.29.0"
 embedMongo = "4.24.0"
 apacheCommonsCsv = "1.14.1"
+tomcat = "11.0.22"
+netty = "4.2.13.Final"
+jacksonBom = "3.1.1"
 
 [plugins]
 spring-boot = { id = "org.springframework.boot", version.ref = "springBoot" }


### PR DESCRIPTION
## 🔎 Détails

- Montée de version de spring à 4.0.6 (et dépendances du BOM associé
- Pin manuel de version de tomcat, netty & jackson-bom pour corriger les CVE restante
- Changement de l'image de base dans la configuration jib pour une image eclipse-temurin DHI
- Mise à jour du workflow de build de l'image du dispatcher pour inclure une étape de login au registry DHI

## ☑️ Validation

- [ ] Build avec succès (cf [action](https://github.com/ansforge/SAMU-Hub-Sante/actions/runs/26624628918))
- [ ] Dispatcher fonctionnel (déployé sur le périmètre 15-15 sur integration) : valider la circulation de messages entre 2 SAMU
- [ ] Réduction des vulnérabilités : on passe de 30+ vulnérabilités CRITICAL + HIGH à 0
```
docker pull ghcr.io/ansforge/dispatcher:1.11.1-model-3.4.1-rc.2 --platform linux/amd64
trivy image --scanners vuln --vex repo ghcr.io/ansforge/dispatcher:1.11.1-model-3.4.1-rc.2

docker pull ghcr.io/ansforge/dispatcher:1.11.2-rc.1-model-3.4.1-rc.2 --platform linux/amd64
trivy image --scanners vuln --vex repo ghcr.io/ansforge/dispatcher:1.11.2-rc.1-model-3.4.1-rc.2
```