### PR TITLE
chore(annuaire): fix python version in CI to 3.14

### DIFF
--- a/.github/workflows/annuaire-ci.yml
+++ b/.github/workflows/annuaire-ci.yml
@@ -28,7 +28,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install dependencies
         run: uv sync


### PR DESCRIPTION
## 🔎 Détails

- Hotfix suite à un oubli lors de la montée de version de Python à 3.14 pour l'annuaire

