### PR TITLE
feat(annuaire): exposer la list des clients avec filtre par perimètre

### DIFF
--- a/tools/annuaire/annuaire.py
+++ b/tools/annuaire/annuaire.py
@@ -93,7 +93,11 @@ def build_annuaire_client_entry(client: dict) -> dict:
 
 
 def build_annuaire_clients(clients: list[dict]) -> list[dict]:
-    return [build_annuaire_client_entry(c) for c in clients if isinstance(c.get("annuaire"), dict)]
+    return [
+        build_annuaire_client_entry(c)
+        for c in clients
+        if isinstance(c.get("annuaire"), dict)
+    ]
 
 
 def register_routes(app):

--- a/tools/annuaire/annuaire.py
+++ b/tools/annuaire/annuaire.py
@@ -88,7 +88,7 @@ def register_routes(app):
     @app.get(f"{CLIENTS_ENDPOINT}/<perimeter>")
     def get_clients_by_perimeter(perimeter):
         if perimeter not in VALID_PERIMETERS:
-            return jsonify({"error": "Invalid perimeter"}), 400
+            return jsonify({"error": "Invalid perimeter", "valid_perimeters": sorted(VALID_PERIMETERS)}), 400
         filtered = [
             client
             for client in app.config[ANNUAIRE_CLIENTS_DATA_KEY]

--- a/tools/annuaire/annuaire.py
+++ b/tools/annuaire/annuaire.py
@@ -96,11 +96,7 @@ def build_annuaire_client_entry(client: dict) -> dict:
 
 
 def build_annuaire_clients(clients: list[dict]) -> list[dict]:
-    annuaire_clients = []
-    for client in clients:
-        if isinstance(client.get("annuaire"), dict):
-            annuaire_clients.append(build_annuaire_client_entry(client))
-    return annuaire_clients
+    return [build_annuaire_client_entry(c) for c in clients if isinstance(c.get("annuaire"), dict)]
 
 
 def register_routes(app):

--- a/tools/annuaire/annuaire.py
+++ b/tools/annuaire/annuaire.py
@@ -25,13 +25,13 @@ TOPOLOGY_TO_LEGACY_KEY = {
 }
 
 ANNUAIRE_TO_PERIMETER_KEY = {
-    "lrm": ("15-15", "lrmPerimeterVersions"),
-    "cap": ("15-cap", "lrmPerimeterVersions"),
-    "portail": ("15-portail", "lrmPerimeterVersions"),
-    "cnr114": ("15-cnr114", "cnr114PerimeterVersions"),
-    "cisu": ("15-nexsis", "cisuPerimeterVersions"),
-    "smur": ("15-smur", "smurPerimeterVersions"),
-    "gps": ("15-gps", "gpsPerimeterVersions"),
+    "lrm": "15-15",
+    "cap": "15-cap",
+    "portail": "15-portail",
+    "cnr114": "15-cnr114",
+    "cisu": "15-nexsis",
+    "smur": "15-smur",
+    "gps": "15-gps",
 }
 
 
@@ -75,15 +75,8 @@ def resolve_perimeters(client: dict) -> dict:
         return {}
 
     perimeters = {}
-    for annuaire_key, (perimeter_key, topology_key) in ANNUAIRE_TO_PERIMETER_KEY.items():
-        if not annuaire.get(annuaire_key):
-            continue
-
-        versions = client.get(topology_key, [])
-        if isinstance(versions, list) and versions:
-            perimeters[perimeter_key] = versions[0]
-        elif isinstance(versions, str) and versions:
-            perimeters[perimeter_key] = versions
+    for annuaire_key, perimeter_key in ANNUAIRE_TO_PERIMETER_KEY.items():
+        perimeters[perimeter_key] = bool(annuaire.get(annuaire_key, False))
 
     return perimeters
 
@@ -122,7 +115,7 @@ def register_routes(app):
         filtered = [
             client
             for client in app.config[ANNUAIRE_CLIENTS_DATA_KEY]
-            if perimeter in client["perimeters"]
+            if client["perimeters"].get(perimeter) is True
         ]
         return jsonify(filtered)
 

--- a/tools/annuaire/annuaire.py
+++ b/tools/annuaire/annuaire.py
@@ -7,10 +7,12 @@ import yaml
 ENVIRONMENT = os.environ.get("ENVIRONMENT")
 
 API_ENDPOINT = "/annuaire/api"
+CLIENTS_ENDPOINT = f"{API_ENDPOINT}/clients"
 HEALTH_ENDPOINT = "/annuaire/health"
 
 VALUES_PATH = os.environ.get("VALUES_PATH", "/config/topology/values.yaml")
 CLIENTS_DATA_KEY = "CLIENTS_DATA"
+ANNUAIRE_CLIENTS_DATA_KEY = "ANNUAIRE_CLIENTS_DATA"
 
 TOPOLOGY_ROOT_KEY = "annuaire"
 TOPOLOGY_CLIENTS_KEY = "clients"
@@ -20,6 +22,16 @@ TOPOLOGY_TO_LEGACY_KEY = {
     "smurPerimeterVersions": "P: 15-smur",
     "cisuPerimeterVersions": "P: 15-nexsis",
     "gpsPerimeterVersions": "P: 15-gps",
+}
+
+ANNUAIRE_TO_PERIMETER_KEY = {
+    "lrm": ("15-15", "lrmPerimeterVersions"),
+    "cap": ("15-cap", "lrmPerimeterVersions"),
+    "portail": ("15-portail", "lrmPerimeterVersions"),
+    "cnr114": ("15-cnr114", "cnr114PerimeterVersions"),
+    "cisu": ("15-nexsis", "cisuPerimeterVersions"),
+    "smur": ("15-smur", "smurPerimeterVersions"),
+    "gps": ("15-gps", "gpsPerimeterVersions"),
 }
 
 
@@ -57,10 +69,62 @@ def build_client_entry(client: dict) -> dict:
     return entry
 
 
+def resolve_perimeters(client: dict) -> dict:
+    annuaire = client.get("annuaire")
+    if not isinstance(annuaire, dict):
+        return {}
+
+    perimeters = {}
+    for annuaire_key, (perimeter_key, topology_key) in ANNUAIRE_TO_PERIMETER_KEY.items():
+        if not annuaire.get(annuaire_key):
+            continue
+
+        versions = client.get(topology_key, [])
+        if isinstance(versions, list) and versions:
+            perimeters[perimeter_key] = versions[0]
+        elif isinstance(versions, str) and versions:
+            perimeters[perimeter_key] = versions
+
+    return perimeters
+
+
+def build_annuaire_client_entry(client: dict) -> dict:
+    return {
+        "client_id": client["client_id"],
+        "client_name": client.get("client_name", ""),
+        "client_type": client.get("client_type", ""),
+        "editor": client.get("editor", ""),
+        "directCISU": bool(client.get("directCISU", False)),
+        "isLinkedToNexsis": bool(client.get("isLinkedToNexsis", False)),
+        "perimeters": resolve_perimeters(client),
+    }
+
+
+def build_annuaire_clients(clients: list[dict]) -> list[dict]:
+    annuaire_clients = []
+    for client in clients:
+        if isinstance(client.get("annuaire"), dict):
+            annuaire_clients.append(build_annuaire_client_entry(client))
+    return annuaire_clients
+
+
 def register_routes(app):
     @app.get(API_ENDPOINT)
     def get_json():
         return jsonify(app.config[CLIENTS_DATA_KEY])
+
+    @app.get(CLIENTS_ENDPOINT)
+    def get_clients():
+        return jsonify(app.config[ANNUAIRE_CLIENTS_DATA_KEY])
+
+    @app.get(f"{CLIENTS_ENDPOINT}/<perimeter>")
+    def get_clients_by_perimeter(perimeter):
+        filtered = [
+            client
+            for client in app.config[ANNUAIRE_CLIENTS_DATA_KEY]
+            if perimeter in client["perimeters"]
+        ]
+        return jsonify(filtered)
 
     @app.get(HEALTH_ENDPOINT)
     def health_check():
@@ -72,6 +136,7 @@ def create_app():
     register_routes(app)
     clients = load_clients(VALUES_PATH)
     app.config[CLIENTS_DATA_KEY] = [build_client_entry(c) for c in clients]
+    app.config[ANNUAIRE_CLIENTS_DATA_KEY] = build_annuaire_clients(clients)
     return app
 
 

--- a/tools/annuaire/annuaire.py
+++ b/tools/annuaire/annuaire.py
@@ -88,9 +88,6 @@ def build_annuaire_client_entry(client: dict) -> dict:
         "client_id": client.get("client_id", ""),
         "client_name": client.get("client_name", ""),
         "client_type": client.get("client_type", ""),
-        "editor": client.get("editor", ""),
-        "directCISU": bool(client.get("directCISU", False)),
-        "isLinkedToNexsis": bool(client.get("isLinkedToNexsis", False)),
         "perimeters": resolve_perimeters(client),
     }
 

--- a/tools/annuaire/annuaire.py
+++ b/tools/annuaire/annuaire.py
@@ -65,7 +65,7 @@ def resolve_perimeters(client: dict) -> dict:
 
 def build_annuaire_client_entry(client: dict) -> dict:
     return {
-        "client_id": client.get("client_id", ""),
+        "client_id": client["client_id"],
         "client_name": client.get("client_name", ""),
         "client_type": client.get("client_type", ""),
         "perimeters": resolve_perimeters(client),

--- a/tools/annuaire/annuaire.py
+++ b/tools/annuaire/annuaire.py
@@ -34,6 +34,8 @@ ANNUAIRE_TO_PERIMETER_KEY = {
     "gps": "15-gps",
 }
 
+VALID_PERIMETERS = frozenset(ANNUAIRE_TO_PERIMETER_KEY.values())
+
 
 def load_clients(path: str) -> list[dict]:
     try:
@@ -112,6 +114,8 @@ def register_routes(app):
 
     @app.get(f"{CLIENTS_ENDPOINT}/<perimeter>")
     def get_clients_by_perimeter(perimeter):
+        if perimeter not in VALID_PERIMETERS:
+            return jsonify({"error": "Invalid perimeter"}), 400
         filtered = [
             client
             for client in app.config[ANNUAIRE_CLIENTS_DATA_KEY]

--- a/tools/annuaire/annuaire.py
+++ b/tools/annuaire/annuaire.py
@@ -59,7 +59,7 @@ def load_clients(path: str) -> list[dict]:
 
 def build_client_entry(client: dict) -> dict:
     entry = {
-        "client_id": client["client_id"],
+        "client_id": client.get("client_id", ""),
         "editor": client.get("editor", ""),
         "directCISU": client.get("directCISU", False),
     }
@@ -83,7 +83,7 @@ def resolve_perimeters(client: dict) -> dict:
 
 def build_annuaire_client_entry(client: dict) -> dict:
     return {
-        "client_id": client["client_id"],
+        "client_id": client.get("client_id", ""),
         "client_name": client.get("client_name", ""),
         "client_type": client.get("client_type", ""),
         "editor": client.get("editor", ""),

--- a/tools/annuaire/annuaire.py
+++ b/tools/annuaire/annuaire.py
@@ -88,7 +88,12 @@ def register_routes(app):
     @app.get(f"{CLIENTS_ENDPOINT}/<perimeter>")
     def get_clients_by_perimeter(perimeter):
         if perimeter not in VALID_PERIMETERS:
-            return jsonify({"error": "Invalid perimeter", "valid_perimeters": sorted(VALID_PERIMETERS)}), 400
+            return jsonify(
+                {
+                    "error": "Invalid perimeter",
+                    "valid_perimeters": sorted(VALID_PERIMETERS),
+                }
+            ), 400
         filtered = [
             client
             for client in app.config[ANNUAIRE_CLIENTS_DATA_KEY]

--- a/tools/annuaire/annuaire.py
+++ b/tools/annuaire/annuaire.py
@@ -11,18 +11,10 @@ CLIENTS_ENDPOINT = f"{API_ENDPOINT}/clients"
 HEALTH_ENDPOINT = "/annuaire/health"
 
 VALUES_PATH = os.environ.get("VALUES_PATH", "/config/topology/values.yaml")
-CLIENTS_DATA_KEY = "CLIENTS_DATA"
 ANNUAIRE_CLIENTS_DATA_KEY = "ANNUAIRE_CLIENTS_DATA"
 
 TOPOLOGY_ROOT_KEY = "annuaire"
 TOPOLOGY_CLIENTS_KEY = "clients"
-
-TOPOLOGY_TO_LEGACY_KEY = {
-    "lrmPerimeterVersions": "P: 15-15",
-    "smurPerimeterVersions": "P: 15-smur",
-    "cisuPerimeterVersions": "P: 15-nexsis",
-    "gpsPerimeterVersions": "P: 15-gps",
-}
 
 ANNUAIRE_TO_PERIMETER_KEY = {
     "lrm": "15-15",
@@ -59,18 +51,6 @@ def load_clients(path: str) -> list[dict]:
         raise RuntimeError(f"Failed to load clients from {path}: {e}") from e
 
 
-def build_client_entry(client: dict) -> dict:
-    entry = {
-        "client_id": client.get("client_id", ""),
-        "editor": client.get("editor", ""),
-        "directCISU": client.get("directCISU", False),
-    }
-    for topo_key, legacy_key in TOPOLOGY_TO_LEGACY_KEY.items():
-        if topo_key in client:
-            entry[legacy_key] = client[topo_key]
-    return entry
-
-
 def resolve_perimeters(client: dict) -> dict:
     annuaire = client.get("annuaire")
     if not isinstance(annuaire, dict):
@@ -101,10 +81,6 @@ def build_annuaire_clients(clients: list[dict]) -> list[dict]:
 
 
 def register_routes(app):
-    @app.get(API_ENDPOINT)
-    def get_json():
-        return jsonify(app.config[CLIENTS_DATA_KEY])
-
     @app.get(CLIENTS_ENDPOINT)
     def get_clients():
         return jsonify(app.config[ANNUAIRE_CLIENTS_DATA_KEY])
@@ -129,7 +105,6 @@ def create_app():
     app = Flask(__name__)
     register_routes(app)
     clients = load_clients(VALUES_PATH)
-    app.config[CLIENTS_DATA_KEY] = [build_client_entry(c) for c in clients]
     app.config[ANNUAIRE_CLIENTS_DATA_KEY] = build_annuaire_clients(clients)
     return app
 

--- a/tools/annuaire/fixtures/values_annuaire_api.yaml
+++ b/tools/annuaire/fixtures/values_annuaire_api.yaml
@@ -1,0 +1,29 @@
+annuaire:
+  clients:
+    - client_id: fr.health.samu750
+      client_name: SAMU 750
+      client_type: SAMU
+      editor: Editeur A
+      lrmPerimeterVersions: ["2.1"]
+      cisuPerimeterVersions: ["1.9"]
+      directCISU: false
+      isLinkedToNexsis: false
+      annuaire:
+        lrm: true
+        cap: true
+        cisu: true
+    - client_id: fr.fire.sdis750
+      client_name: SDIS 750
+      client_type: SDIS
+      editor: Editeur Fire
+      cisuPerimeterVersions: ["1.9"]
+      directCISU: true
+      isLinkedToNexsis: true
+      annuaire:
+        cisu: true
+    - client_id: fr.health.fire
+      client_name: NexSIS Fire
+      client_type: NEXSIS
+      editor: NexSIS
+      cisuPerimeterVersions: ["1.9"]
+      directCISU: true

--- a/tools/annuaire/test_annuaire.py
+++ b/tools/annuaire/test_annuaire.py
@@ -222,6 +222,8 @@ class AnnuaireClientsApiTestCase(unittest.TestCase):
         response_unknown = self.http.get(f"{CLIENTS_ENDPOINT}/inconnu")
         self.assertEqual(response_unknown.status_code, 400)
         self.assertIn("error", response_unknown.json)
+        self.assertIn("valid_perimeters", response_unknown.json)
+        self.assertIsInstance(response_unknown.json["valid_perimeters"], list)
 
     def test_clients_filter_rejects_all_unknown_perimeters(self):
         for invalid in ["unknown", "P: 15-15", "injection-attempt"]:

--- a/tools/annuaire/test_annuaire.py
+++ b/tools/annuaire/test_annuaire.py
@@ -216,7 +216,9 @@ class AnnuaireClientsApiTestCase(unittest.TestCase):
         ids = [entry["client_id"] for entry in data]
         self.assertEqual(ids, ["fr.health.samu750", "fr.fire.sdis750"])
 
-        samu = next(entry for entry in data if entry["client_id"] == "fr.health.samu750")
+        samu = next(
+            entry for entry in data if entry["client_id"] == "fr.health.samu750"
+        )
         self.assertEqual(samu["client_name"], "SAMU 750")
         self.assertEqual(samu["client_type"], "SAMU")
         self.assertNotIn("editor", samu)

--- a/tools/annuaire/test_annuaire.py
+++ b/tools/annuaire/test_annuaire.py
@@ -139,108 +139,6 @@ class AnnuaireTestCase(unittest.TestCase):
         self.assertIn("Failed to load clients from", str(ctx.exception))
         self.assertTrue(any("Failed to load" in line for line in cm.output))
 
-    def test_clients_without_annuaire_key_are_excluded(self):
-        with mock.patch(VALUES_PATH_PATCH, ANNULAIRE_API_FIXTURE_PATH):
-            app = annuaire.create_app()
-            client = app.test_client()
-            response = client.get(CLIENTS_ENDPOINT)
-            self.assertEqual(response.status_code, 200)
-            ids = [entry["client_id"] for entry in response.json]
-            self.assertNotIn("fr.health.fire", ids)
-
-    def test_clients_api_returns_only_clients_with_annuaire(self):
-        with mock.patch(VALUES_PATH_PATCH, ANNULAIRE_API_FIXTURE_PATH):
-            app = annuaire.create_app()
-            client = app.test_client()
-            response = client.get(CLIENTS_ENDPOINT)
-            self.assertEqual(response.status_code, 200)
-            data = response.json
-
-            self.assertEqual(len(data), 2)
-            ids = [entry["client_id"] for entry in data]
-            self.assertEqual(ids, ["fr.health.samu750", "fr.fire.sdis750"])
-
-            samu = next(entry for entry in data if entry["client_id"] == "fr.health.samu750")
-            self.assertEqual(samu["client_name"], "SAMU 750")
-            self.assertEqual(samu["client_type"], "SAMU")
-            self.assertFalse(samu["directCISU"])
-            self.assertFalse(samu["isLinkedToNexsis"])
-            self.assertEqual(
-                samu["perimeters"],
-                {
-                    "15-15": True,
-                    "15-cap": True,
-                    "15-portail": False,
-                    "15-cnr114": False,
-                    "15-nexsis": True,
-                    "15-smur": False,
-                    "15-gps": False,
-                },
-            )
-
-            sdis = next(entry for entry in data if entry["client_id"] == "fr.fire.sdis750")
-            self.assertEqual(
-                sdis["perimeters"],
-                {
-                    "15-15": False,
-                    "15-cap": False,
-                    "15-portail": False,
-                    "15-cnr114": False,
-                    "15-nexsis": True,
-                    "15-smur": False,
-                    "15-gps": False,
-                },
-            )
-            self.assertTrue(sdis["directCISU"])
-            self.assertTrue(sdis["isLinkedToNexsis"])
-
-    def test_clients_api_exposes_false_for_not_implemented_perimeters(self):
-        with mock.patch(VALUES_PATH_PATCH, ANNULAIRE_API_FIXTURE_PATH):
-            app = annuaire.create_app()
-            client = app.test_client()
-            response = client.get(CLIENTS_ENDPOINT)
-            self.assertEqual(response.status_code, 200)
-            data = response.json
-
-            sdis = next(entry for entry in data if entry["client_id"] == "fr.fire.sdis750")
-            self.assertFalse(sdis["perimeters"]["15-15"])
-            self.assertFalse(sdis["perimeters"]["15-cap"])
-
-    def test_clients_api_filter_by_perimeter(self):
-        with mock.patch(VALUES_PATH_PATCH, ANNULAIRE_API_FIXTURE_PATH):
-            app = annuaire.create_app()
-            client = app.test_client()
-
-            response_1515 = client.get(f"{CLIENTS_ENDPOINT}/15-15")
-            self.assertEqual(response_1515.status_code, 200)
-            self.assertEqual(len(response_1515.json), 1)
-            self.assertEqual(response_1515.json[0]["client_id"], "fr.health.samu750")
-
-            response_cap = client.get(f"{CLIENTS_ENDPOINT}/15-cap")
-            self.assertEqual(response_cap.status_code, 200)
-            self.assertEqual(len(response_cap.json), 1)
-            self.assertEqual(response_cap.json[0]["client_id"], "fr.health.samu750")
-
-            response_nexsis = client.get(f"{CLIENTS_ENDPOINT}/15-nexsis")
-            self.assertEqual(response_nexsis.status_code, 200)
-            self.assertEqual(len(response_nexsis.json), 2)
-
-            response_unknown = client.get(f"{CLIENTS_ENDPOINT}/inconnu")
-            self.assertEqual(response_unknown.status_code, 400)
-            self.assertIn("error", response_unknown.json)
-
-    def test_clients_filter_rejects_all_unknown_perimeters(self):
-        with mock.patch(VALUES_PATH_PATCH, ANNULAIRE_API_FIXTURE_PATH):
-            app = annuaire.create_app()
-            client = app.test_client()
-            for invalid in ["unknown", "P: 15-15", "injection-attempt"]:
-                response = client.get(f"{CLIENTS_ENDPOINT}/{invalid}")
-                self.assertEqual(
-                    response.status_code,
-                    400,
-                    msg=f"Expected 400 for perimeter '{invalid}'",
-                )
-
     def test_resolve_perimeters_missing_topology_key(self):
         client = {
             "client_id": "fr.health.cap-only",
@@ -292,6 +190,99 @@ class AnnuaireTestCase(unittest.TestCase):
                 "15-gps": False,
             },
         )
+
+
+class AnnuaireClientsApiTestCase(unittest.TestCase):
+    def setUp(self):
+        self.patcher = mock.patch(VALUES_PATH_PATCH, ANNULAIRE_API_FIXTURE_PATH)
+        self.patcher.start()
+        self.http = annuaire.create_app().test_client()
+
+    def tearDown(self):
+        self.patcher.stop()
+
+    def test_clients_without_annuaire_key_are_excluded(self):
+        response = self.http.get(CLIENTS_ENDPOINT)
+        self.assertEqual(response.status_code, 200)
+        ids = [entry["client_id"] for entry in response.json]
+        self.assertNotIn("fr.health.fire", ids)
+
+    def test_clients_api_returns_only_clients_with_annuaire(self):
+        response = self.http.get(CLIENTS_ENDPOINT)
+        self.assertEqual(response.status_code, 200)
+        data = response.json
+
+        self.assertEqual(len(data), 2)
+        ids = [entry["client_id"] for entry in data]
+        self.assertEqual(ids, ["fr.health.samu750", "fr.fire.sdis750"])
+
+        samu = next(entry for entry in data if entry["client_id"] == "fr.health.samu750")
+        self.assertEqual(samu["client_name"], "SAMU 750")
+        self.assertEqual(samu["client_type"], "SAMU")
+        self.assertFalse(samu["directCISU"])
+        self.assertFalse(samu["isLinkedToNexsis"])
+        self.assertEqual(
+            samu["perimeters"],
+            {
+                "15-15": True,
+                "15-cap": True,
+                "15-portail": False,
+                "15-cnr114": False,
+                "15-nexsis": True,
+                "15-smur": False,
+                "15-gps": False,
+            },
+        )
+
+        sdis = next(entry for entry in data if entry["client_id"] == "fr.fire.sdis750")
+        self.assertEqual(
+            sdis["perimeters"],
+            {
+                "15-15": False,
+                "15-cap": False,
+                "15-portail": False,
+                "15-cnr114": False,
+                "15-nexsis": True,
+                "15-smur": False,
+                "15-gps": False,
+            },
+        )
+        self.assertTrue(sdis["directCISU"])
+        self.assertTrue(sdis["isLinkedToNexsis"])
+
+    def test_clients_api_exposes_false_for_not_implemented_perimeters(self):
+        data = self.http.get(CLIENTS_ENDPOINT).json
+        sdis = next(entry for entry in data if entry["client_id"] == "fr.fire.sdis750")
+        self.assertFalse(sdis["perimeters"]["15-15"])
+        self.assertFalse(sdis["perimeters"]["15-cap"])
+
+    def test_clients_api_filter_by_perimeter(self):
+        response_1515 = self.http.get(f"{CLIENTS_ENDPOINT}/15-15")
+        self.assertEqual(response_1515.status_code, 200)
+        self.assertEqual(len(response_1515.json), 1)
+        self.assertEqual(response_1515.json[0]["client_id"], "fr.health.samu750")
+
+        response_cap = self.http.get(f"{CLIENTS_ENDPOINT}/15-cap")
+        self.assertEqual(response_cap.status_code, 200)
+        self.assertEqual(len(response_cap.json), 1)
+        self.assertEqual(response_cap.json[0]["client_id"], "fr.health.samu750")
+
+        response_nexsis = self.http.get(f"{CLIENTS_ENDPOINT}/15-nexsis")
+        self.assertEqual(response_nexsis.status_code, 200)
+        self.assertEqual(len(response_nexsis.json), 2)
+
+        response_unknown = self.http.get(f"{CLIENTS_ENDPOINT}/inconnu")
+        self.assertEqual(response_unknown.status_code, 400)
+        self.assertIn("error", response_unknown.json)
+
+    def test_clients_filter_rejects_all_unknown_perimeters(self):
+        for invalid in ["unknown", "P: 15-15", "injection-attempt"]:
+            response = self.http.get(f"{CLIENTS_ENDPOINT}/{invalid}")
+            self.assertEqual(
+                response.status_code,
+                400,
+                msg=f"Expected 400 for perimeter '{invalid}'",
+            )
 
 
 if __name__ == "__main__":

--- a/tools/annuaire/test_annuaire.py
+++ b/tools/annuaire/test_annuaire.py
@@ -9,7 +9,10 @@ import annuaire
 from annuaire import (
     load_clients,
     build_client_entry,
+    resolve_perimeters,
+    build_annuaire_clients,
     API_ENDPOINT,
+    CLIENTS_ENDPOINT,
     HEALTH_ENDPOINT,
     TOPOLOGY_ROOT_KEY,
     TOPOLOGY_CLIENTS_KEY,
@@ -17,6 +20,7 @@ from annuaire import (
 
 FIXTURE_DIR = os.path.join(os.path.dirname(__file__), "fixtures")
 FIXTURE_PATH = os.path.join(FIXTURE_DIR, "values.yaml")
+ANNULAIRE_API_FIXTURE_PATH = os.path.join(FIXTURE_DIR, "values_annuaire_api.yaml")
 VALUES_PATH_PATCH = "annuaire.VALUES_PATH"
 
 
@@ -134,6 +138,98 @@ class AnnuaireTestCase(unittest.TestCase):
                 load_clients(path)
         self.assertIn("Failed to load clients from", str(ctx.exception))
         self.assertTrue(any("Failed to load" in line for line in cm.output))
+
+    def test_clients_api_returns_only_clients_with_annuaire(self):
+        with mock.patch(VALUES_PATH_PATCH, ANNULAIRE_API_FIXTURE_PATH):
+            app = annuaire.create_app()
+            client = app.test_client()
+            response = client.get(CLIENTS_ENDPOINT)
+            self.assertEqual(response.status_code, 200)
+            data = response.json
+
+            self.assertEqual(len(data), 2)
+            ids = [entry["client_id"] for entry in data]
+            self.assertEqual(ids, ["fr.health.samu750", "fr.fire.sdis750"])
+
+            samu = next(entry for entry in data if entry["client_id"] == "fr.health.samu750")
+            self.assertEqual(samu["client_name"], "SAMU 750")
+            self.assertEqual(samu["client_type"], "SAMU")
+            self.assertFalse(samu["directCISU"])
+            self.assertFalse(samu["isLinkedToNexsis"])
+            self.assertEqual(
+                samu["perimeters"],
+                {"15-15": "2.1", "15-cap": "2.1", "15-nexsis": "1.9"},
+            )
+
+            sdis = next(entry for entry in data if entry["client_id"] == "fr.fire.sdis750")
+            self.assertEqual(sdis["perimeters"], {"15-nexsis": "1.9"})
+            self.assertTrue(sdis["directCISU"])
+            self.assertTrue(sdis["isLinkedToNexsis"])
+
+    def test_clients_api_omits_perimeter_without_version(self):
+        with mock.patch(VALUES_PATH_PATCH, ANNULAIRE_API_FIXTURE_PATH):
+            app = annuaire.create_app()
+            client = app.test_client()
+            response = client.get(CLIENTS_ENDPOINT)
+            self.assertEqual(response.status_code, 200)
+            data = response.json
+
+            sdis = next(entry for entry in data if entry["client_id"] == "fr.fire.sdis750")
+            self.assertNotIn("15-15", sdis["perimeters"])
+            self.assertNotIn("15-cap", sdis["perimeters"])
+
+    def test_clients_api_filter_by_perimeter(self):
+        with mock.patch(VALUES_PATH_PATCH, ANNULAIRE_API_FIXTURE_PATH):
+            app = annuaire.create_app()
+            client = app.test_client()
+
+            response_1515 = client.get(f"{CLIENTS_ENDPOINT}/15-15")
+            self.assertEqual(response_1515.status_code, 200)
+            self.assertEqual(len(response_1515.json), 1)
+            self.assertEqual(response_1515.json[0]["client_id"], "fr.health.samu750")
+
+            response_cap = client.get(f"{CLIENTS_ENDPOINT}/15-cap")
+            self.assertEqual(response_cap.status_code, 200)
+            self.assertEqual(len(response_cap.json), 1)
+            self.assertEqual(response_cap.json[0]["client_id"], "fr.health.samu750")
+
+            response_nexsis = client.get(f"{CLIENTS_ENDPOINT}/15-nexsis")
+            self.assertEqual(response_nexsis.status_code, 200)
+            self.assertEqual(len(response_nexsis.json), 2)
+
+            response_unknown = client.get(f"{CLIENTS_ENDPOINT}/inconnu")
+            self.assertEqual(response_unknown.status_code, 200)
+            self.assertEqual(response_unknown.json, [])
+
+    def test_resolve_perimeters_missing_topology_key(self):
+        client = {
+            "client_id": "fr.health.cap-only",
+            "annuaire": {"lrm": True, "cap": True},
+            "editor": "ANS",
+        }
+        perimeters = resolve_perimeters(client)
+        self.assertEqual(perimeters, {})
+
+    def test_build_annuaire_clients(self):
+        clients = [
+            {
+                "client_id": "fr.health.samu750",
+                "client_name": "SAMU 750",
+                "client_type": "SAMU",
+                "editor": "Editeur A",
+                "lrmPerimeterVersions": ["2.1"],
+                "annuaire": {"lrm": True},
+            },
+            {
+                "client_id": "fr.health.ignore",
+                "editor": "ANS",
+            },
+        ]
+
+        result = build_annuaire_clients(clients)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["client_id"], "fr.health.samu750")
+        self.assertEqual(result[0]["perimeters"], {"15-15": "2.1"})
 
 
 if __name__ == "__main__":

--- a/tools/annuaire/test_annuaire.py
+++ b/tools/annuaire/test_annuaire.py
@@ -8,10 +8,8 @@ import yaml
 import annuaire
 from annuaire import (
     load_clients,
-    build_client_entry,
     resolve_perimeters,
     build_annuaire_clients,
-    API_ENDPOINT,
     CLIENTS_ENDPOINT,
     HEALTH_ENDPOINT,
     TOPOLOGY_ROOT_KEY,
@@ -31,36 +29,6 @@ class AnnuaireTestCase(unittest.TestCase):
     def tearDown(self):
         self.tempdir.cleanup()
 
-    def test_api(self):
-        with mock.patch(VALUES_PATH_PATCH, FIXTURE_PATH):
-            app = annuaire.create_app()
-            client = app.test_client()
-            response = client.get(API_ENDPOINT)
-            self.assertEqual(response.status_code, 200)
-            data = response.json
-            self.assertIsInstance(data, list)
-            self.assertEqual(len(data), 4)
-            ids = [entry["client_id"] for entry in data]
-            self.assertIn("fr.health.samu750", ids)
-            self.assertIn("fr.health.test.samuv1", ids)
-            self.assertIn("fr.health.fire", ids)
-            self.assertIn("fr.health.test.samuC", ids)
-            # full-perimeter client
-            samu = next(e for e in data if e["client_id"] == "fr.health.samu750")
-            self.assertEqual(samu["P: 15-15"], ["2.1"])
-            self.assertEqual(samu["P: 15-nexsis"], ["1.9"])
-            self.assertFalse(samu["directCISU"])
-            # directCISU client (CISU only)
-            fire = next(e for e in data if e["client_id"] == "fr.health.fire")
-            self.assertTrue(fire["directCISU"])
-            self.assertEqual(fire["P: 15-nexsis"], ["1.9"])
-            self.assertNotIn("P: 15-15", fire)
-            # full-perimeter client with directCISU
-            samuC = next(e for e in data if e["client_id"] == "fr.health.test.samuC")
-            self.assertTrue(samuC["directCISU"])
-            self.assertEqual(samuC["P: 15-15"], ["1.5", "2.0", "2.1"])
-            self.assertEqual(samuC["P: 15-nexsis"], ["1.9"])
-
     def test_healthcheck(self):
         with mock.patch(VALUES_PATH_PATCH, FIXTURE_PATH):
             app = annuaire.create_app()
@@ -78,29 +46,6 @@ class AnnuaireTestCase(unittest.TestCase):
         self.assertEqual(clients[1]["client_id"], "fr.health.test.samuv1")
         self.assertEqual(clients[2]["client_id"], "fr.health.fire")
         self.assertEqual(clients[3]["client_id"], "fr.health.test.samuC")
-
-    def test_build_client_entry_with_lrm(self):
-        client = {
-            "client_id": "fr.health.samu750",
-            "editor": "Editeur A",
-            "lrmPerimeterVersions": ["2.1"],
-            "directCISU": False,
-        }
-        entry = build_client_entry(client)
-        self.assertEqual(entry["P: 15-15"], ["2.1"])
-        self.assertNotIn("P: 15-smur", entry)
-        self.assertNotIn("P: 15-nexsis", entry)
-
-    def test_build_client_entry_direct_cisu(self):
-        client = {
-            "client_id": "fr.health.fire",
-            "editor": "NexSIS",
-            "directCISU": True,
-            "cisuPerimeterVersions": ["1.9"],
-        }
-        entry = build_client_entry(client)
-        self.assertTrue(entry["directCISU"])
-        self.assertEqual(entry["P: 15-nexsis"], ["1.9"])
 
     def test_load_clients_file_not_found(self):
         missing_path = os.path.join(self.tempdir.name, "nonexistent.yaml")

--- a/tools/annuaire/test_annuaire.py
+++ b/tools/annuaire/test_annuaire.py
@@ -158,15 +158,34 @@ class AnnuaireTestCase(unittest.TestCase):
             self.assertFalse(samu["isLinkedToNexsis"])
             self.assertEqual(
                 samu["perimeters"],
-                {"15-15": "2.1", "15-cap": "2.1", "15-nexsis": "1.9"},
+                {
+                    "15-15": True,
+                    "15-cap": True,
+                    "15-portail": False,
+                    "15-cnr114": False,
+                    "15-nexsis": True,
+                    "15-smur": False,
+                    "15-gps": False,
+                },
             )
 
             sdis = next(entry for entry in data if entry["client_id"] == "fr.fire.sdis750")
-            self.assertEqual(sdis["perimeters"], {"15-nexsis": "1.9"})
+            self.assertEqual(
+                sdis["perimeters"],
+                {
+                    "15-15": False,
+                    "15-cap": False,
+                    "15-portail": False,
+                    "15-cnr114": False,
+                    "15-nexsis": True,
+                    "15-smur": False,
+                    "15-gps": False,
+                },
+            )
             self.assertTrue(sdis["directCISU"])
             self.assertTrue(sdis["isLinkedToNexsis"])
 
-    def test_clients_api_omits_perimeter_without_version(self):
+    def test_clients_api_exposes_false_for_not_implemented_perimeters(self):
         with mock.patch(VALUES_PATH_PATCH, ANNULAIRE_API_FIXTURE_PATH):
             app = annuaire.create_app()
             client = app.test_client()
@@ -175,8 +194,8 @@ class AnnuaireTestCase(unittest.TestCase):
             data = response.json
 
             sdis = next(entry for entry in data if entry["client_id"] == "fr.fire.sdis750")
-            self.assertNotIn("15-15", sdis["perimeters"])
-            self.assertNotIn("15-cap", sdis["perimeters"])
+            self.assertFalse(sdis["perimeters"]["15-15"])
+            self.assertFalse(sdis["perimeters"]["15-cap"])
 
     def test_clients_api_filter_by_perimeter(self):
         with mock.patch(VALUES_PATH_PATCH, ANNULAIRE_API_FIXTURE_PATH):
@@ -208,7 +227,18 @@ class AnnuaireTestCase(unittest.TestCase):
             "editor": "ANS",
         }
         perimeters = resolve_perimeters(client)
-        self.assertEqual(perimeters, {})
+        self.assertEqual(
+            perimeters,
+            {
+                "15-15": True,
+                "15-cap": True,
+                "15-portail": False,
+                "15-cnr114": False,
+                "15-nexsis": False,
+                "15-smur": False,
+                "15-gps": False,
+            },
+        )
 
     def test_build_annuaire_clients(self):
         clients = [
@@ -229,7 +259,18 @@ class AnnuaireTestCase(unittest.TestCase):
         result = build_annuaire_clients(clients)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["client_id"], "fr.health.samu750")
-        self.assertEqual(result[0]["perimeters"], {"15-15": "2.1"})
+        self.assertEqual(
+            result[0]["perimeters"],
+            {
+                "15-15": True,
+                "15-cap": False,
+                "15-portail": False,
+                "15-cnr114": False,
+                "15-nexsis": False,
+                "15-smur": False,
+                "15-gps": False,
+            },
+        )
 
 
 if __name__ == "__main__":

--- a/tools/annuaire/test_annuaire.py
+++ b/tools/annuaire/test_annuaire.py
@@ -160,7 +160,9 @@ class AnnuaireClientsApiTestCase(unittest.TestCase):
 
     def test_clients_api_response_shape(self):
         data = self.http.get(CLIENTS_ENDPOINT).json
-        samu = next(entry for entry in data if entry["client_id"] == "fr.health.samu750")
+        samu = next(
+            entry for entry in data if entry["client_id"] == "fr.health.samu750"
+        )
         self.assertEqual(samu["client_name"], "SAMU 750")
         self.assertEqual(samu["client_type"], "SAMU")
         self.assertNotIn("editor", samu)

--- a/tools/annuaire/test_annuaire.py
+++ b/tools/annuaire/test_annuaire.py
@@ -139,6 +139,15 @@ class AnnuaireTestCase(unittest.TestCase):
         self.assertIn("Failed to load clients from", str(ctx.exception))
         self.assertTrue(any("Failed to load" in line for line in cm.output))
 
+    def test_clients_without_annuaire_key_are_excluded(self):
+        with mock.patch(VALUES_PATH_PATCH, ANNULAIRE_API_FIXTURE_PATH):
+            app = annuaire.create_app()
+            client = app.test_client()
+            response = client.get(CLIENTS_ENDPOINT)
+            self.assertEqual(response.status_code, 200)
+            ids = [entry["client_id"] for entry in response.json]
+            self.assertNotIn("fr.health.fire", ids)
+
     def test_clients_api_returns_only_clients_with_annuaire(self):
         with mock.patch(VALUES_PATH_PATCH, ANNULAIRE_API_FIXTURE_PATH):
             app = annuaire.create_app()

--- a/tools/annuaire/test_annuaire.py
+++ b/tools/annuaire/test_annuaire.py
@@ -155,15 +155,12 @@ class AnnuaireClientsApiTestCase(unittest.TestCase):
     def test_clients_api_returns_only_clients_with_annuaire(self):
         response = self.http.get(CLIENTS_ENDPOINT)
         self.assertEqual(response.status_code, 200)
-        data = response.json
-
-        self.assertEqual(len(data), 2)
-        ids = [entry["client_id"] for entry in data]
+        ids = [entry["client_id"] for entry in response.json]
         self.assertEqual(ids, ["fr.health.samu750", "fr.fire.sdis750"])
 
-        samu = next(
-            entry for entry in data if entry["client_id"] == "fr.health.samu750"
-        )
+    def test_clients_api_response_shape(self):
+        data = self.http.get(CLIENTS_ENDPOINT).json
+        samu = next(entry for entry in data if entry["client_id"] == "fr.health.samu750")
         self.assertEqual(samu["client_name"], "SAMU 750")
         self.assertEqual(samu["client_type"], "SAMU")
         self.assertNotIn("editor", samu)
@@ -181,22 +178,6 @@ class AnnuaireClientsApiTestCase(unittest.TestCase):
                 "15-gps": False,
             },
         )
-
-        sdis = next(entry for entry in data if entry["client_id"] == "fr.fire.sdis750")
-        self.assertEqual(
-            sdis["perimeters"],
-            {
-                "15-15": False,
-                "15-cap": False,
-                "15-portail": False,
-                "15-cnr114": False,
-                "15-nexsis": True,
-                "15-smur": False,
-                "15-gps": False,
-            },
-        )
-        self.assertNotIn("directCISU", sdis)
-        self.assertNotIn("isLinkedToNexsis", sdis)
 
     def test_clients_api_exposes_false_for_not_implemented_perimeters(self):
         data = self.http.get(CLIENTS_ENDPOINT).json

--- a/tools/annuaire/test_annuaire.py
+++ b/tools/annuaire/test_annuaire.py
@@ -217,8 +217,20 @@ class AnnuaireTestCase(unittest.TestCase):
             self.assertEqual(len(response_nexsis.json), 2)
 
             response_unknown = client.get(f"{CLIENTS_ENDPOINT}/inconnu")
-            self.assertEqual(response_unknown.status_code, 200)
-            self.assertEqual(response_unknown.json, [])
+            self.assertEqual(response_unknown.status_code, 400)
+            self.assertIn("error", response_unknown.json)
+
+    def test_clients_filter_rejects_all_unknown_perimeters(self):
+        with mock.patch(VALUES_PATH_PATCH, ANNULAIRE_API_FIXTURE_PATH):
+            app = annuaire.create_app()
+            client = app.test_client()
+            for invalid in ["unknown", "P: 15-15", "injection-attempt"]:
+                response = client.get(f"{CLIENTS_ENDPOINT}/{invalid}")
+                self.assertEqual(
+                    response.status_code,
+                    400,
+                    msg=f"Expected 400 for perimeter '{invalid}'",
+                )
 
     def test_resolve_perimeters_missing_topology_key(self):
         client = {

--- a/tools/annuaire/test_annuaire.py
+++ b/tools/annuaire/test_annuaire.py
@@ -219,8 +219,9 @@ class AnnuaireClientsApiTestCase(unittest.TestCase):
         samu = next(entry for entry in data if entry["client_id"] == "fr.health.samu750")
         self.assertEqual(samu["client_name"], "SAMU 750")
         self.assertEqual(samu["client_type"], "SAMU")
-        self.assertFalse(samu["directCISU"])
-        self.assertFalse(samu["isLinkedToNexsis"])
+        self.assertNotIn("editor", samu)
+        self.assertNotIn("directCISU", samu)
+        self.assertNotIn("isLinkedToNexsis", samu)
         self.assertEqual(
             samu["perimeters"],
             {
@@ -247,8 +248,8 @@ class AnnuaireClientsApiTestCase(unittest.TestCase):
                 "15-gps": False,
             },
         )
-        self.assertTrue(sdis["directCISU"])
-        self.assertTrue(sdis["isLinkedToNexsis"])
+        self.assertNotIn("directCISU", sdis)
+        self.assertNotIn("isLinkedToNexsis", sdis)
 
     def test_clients_api_exposes_false_for_not_implemented_perimeters(self):
         data = self.http.get(CLIENTS_ENDPOINT).json


### PR DESCRIPTION
## 🔎 Détails

Ajoute deux nouveaux endpoints à l'API Annuaire pour exposer la liste des clients enregistrés dans la topologie et permettre leur filtrage par périmètre fonctionnel.

### Nouveaux endpoints

- **`GET /annuaire/api/clients`** : retourne la liste des clients ayant une clé `annuaire` dans la topologie, avec leurs périmètres fonctionnels sous forme de flags booléens (`true`/`false`).
- **`GET /annuaire/api/clients/<perimeter>`** : filtre les clients par périmètre (ex: `15-15`, `15-nexsis`). Retourne `400` si le périmètre est inconnu.

### Réponse par client

```json
{
  "client_id": "fr.health.samu750",
  "client_name": "SAMU 750",
  "client_type": "SAMU",
  "perimeters": {
    "15-15": true,
    "15-cap": true,
    "15-portail": false,
    "15-cnr114": false,
    "15-nexsis": true,
    "15-smur": false,
    "15-gps": false
  }
}
```

### Points notables

- L'endpoint legacy `GET /annuaire/api` est **supprimé** : seuls les nouveaux endpoints sont exposés
- La réponse n'expose que `client_id`, `client_name`, `client_type` et `perimeters` (pas d'`editor`, `directCISU`, `isLinkedToNexsis`)
- Validation du paramètre `<perimeter>` : retourne `400` avec la liste des périmètres valides si inconnu
- tests pour couverture des endpoints, du filtrage, de la validation sécurité, de l'exclusion des clients sans clé `annuaire`

## 📸 Captures d'écran
<img width="367" height="477" alt="image" src="https://github.com/user-attachments/assets/1464f4d8-1811-4f79-8cf8-4d5d905ec444" />

## 🔗Ticket associé

[7. Exposer la liste des clients avec leurs périmètres fonctionnels via un nouvel endpoint](https://app.asana.com/1/1201445755223134/project/1214554001624211/task/1214700128554164?focus=true)

[8.  Ajouter le filtrage des clients par périmètre dans l'API](https://app.asana.com/1/1201445755223134/project/1214554001624211/task/1214700128554165?focus=true)

## ✅ A vérifier

- [ ] J'ai exécuté les tests e2e du LRM client localement, s'il a été modifié
