### PR TITLE
feat(lrm): filtrage des types de messages par vHost dans le store

### DIFF
--- a/web/lrm/client/store/index.js
+++ b/web/lrm/client/store/index.js
@@ -8,12 +8,20 @@ export const useMainStore = defineStore('main', {
   state: () => ({
     vhostMap: Object.keys(useRuntimeConfig().public.vhostMap).map((vhost) => ({
       vhost,
-      modelVersion: useRuntimeConfig().public.vhostMap[vhost],
+      modelVersion:
+        useRuntimeConfig().public.vhostMap[vhost]?.model_lib_version ||
+        useRuntimeConfig().public.vhostMap[vhost],
+      supported_messages:
+        useRuntimeConfig().public.vhostMap[vhost]?.supported_messages || [],
     })),
     selectedVhost: Object.keys(useRuntimeConfig().public.vhostMap).map(
       (vhost) => ({
         vhost,
-        modelVersion: useRuntimeConfig().public.vhostMap[vhost],
+        modelVersion:
+          useRuntimeConfig().public.vhostMap[vhost]?.model_lib_version ||
+          useRuntimeConfig().public.vhostMap[vhost],
+        supported_messages:
+          useRuntimeConfig().public.vhostMap[vhost]?.supported_messages || [],
       })
     )[0],
     socket: null,
@@ -100,7 +108,9 @@ export const useMainStore = defineStore('main', {
     },
 
     messageTypes(state) {
-      return state._messageTypes;
+      const allowed = state.selectedVhost?.supported_messages;
+      if (!allowed || allowed.length === 0) return state._messageTypes;
+      return state._messageTypes.filter((mt) => allowed.includes(mt.label));
     },
     currentMessageLoaded(state) {
       return !!state.currentMessage?.senderCaseId;
@@ -171,7 +181,7 @@ export const useMainStore = defineStore('main', {
     loadSchemas(source) {
       source = source || 'schemas/json-schema/';
       return Promise.all(
-        this.messageTypes.map(async ({ schemaName }, index) => {
+        this._messageTypes.map(async ({ schemaName }, index) => {
           // eslint-disable-next-line no-undef
           const response = await $fetch(source + schemaName);
           const schema = await JSON.parse(response);
@@ -218,7 +228,7 @@ export const useMainStore = defineStore('main', {
           // }
           // Add schema to already message type infos
           updatedMessageTypes[index] = {
-            ...this.messageTypes[index],
+            ...this._messageTypes[index],
             schema,
           };
         });


### PR DESCRIPTION
## 🔎 Détails

Ajout de la lecture de supported_messages par vHost dans le store Pinia et filtrage des types de messages affichés selon le vHost sélectionné. Le store est désormais synchronisé avec le format généré par Hub-Config (model_lib_version + supported_messages).

## 📸 Captures d'écran
<img width="539" height="79" alt="image" src="https://github.com/user-attachments/assets/b57ec865-78d3-4164-b030-796249f763cc" />
<img width="541" height="82" alt="image" src="https://github.com/user-attachments/assets/2b5923d8-514f-469d-949f-b177f1d1d681" />
<img width="529" height="82" alt="image" src="https://github.com/user-attachments/assets/20204415-55db-4da4-885a-326366d2fdde" />


## 🔗Ticket associé

[Asana](https://app.asana.com/1/1201445755223134/project/1213900980560885/task/1214196701759735?focus=true)
