### PR TITLE
fix(tnr): support vactive

### DIFF
--- a/tools/tnr/src/test/java/tnr/AMQPTestSupport.java
+++ b/tools/tnr/src/test/java/tnr/AMQPTestSupport.java
@@ -37,7 +37,8 @@ abstract class AMQPTestSupport {
             "15-15_v1.5", List.of("fr.health.tnr.samu1-v1", "fr.health.tnr.samu2-v1"),
             "15-15_v2.0", List.of("fr.health.tnr.samu1-v2", "fr.health.tnr.samu2-v2"),
             "15-15_v2.1", List.of("fr.health.tnr.samu1-v3", "fr.health.tnr.samu2-v3"),
-            "15-nexsis_v1.9", List.of("fr.health.fire", "fr.health.tnr.samu2-v3")
+            "15-nexsis_v1.9", List.of("fr.health.tnr.samu2-v3"),
+            "15-nexsis_vactive", List.of("fr.health.fire")
     ));
 
     protected static final String BASE_URL = "https://raw.githubusercontent.com/ansforge/SAMU-Hub-Modeles/refs/tags";

--- a/tools/tnr/src/test/java/tnr/SamuFireTest.java
+++ b/tools/tnr/src/test/java/tnr/SamuFireTest.java
@@ -27,6 +27,8 @@ class SamuFireTest extends AMQPTestSupport {
     protected static final String HUB_NEXSIS_USER_CLIENT_ID = "fr.health.fire";
     protected static final String NEXSIS_SHOVEL_ROUTING_KEY = "fr.fire.sga";
     protected static final String VHOST_15_NEXSIS_V3_TAG = "15-nexsis_v1.9";
+    protected static final String VHOST_15_NEXSIS_VACTIVE_TAG = "15-nexsis_vactive";
+
 
     @Test
     @DisplayName("Send RS-EDA message from samu1_v1 to sdisZ with conversion & transcoding, then send ack")
@@ -43,11 +45,11 @@ class SamuFireTest extends AMQPTestSupport {
         MessageDTO matched = awaitMessage(distributionId);
 
         assertNotNull(matched, "Message " + distributionId + " not received within " + RECEIVE_TIMEOUT_SECS + "s");
-        assertVhostEquals(matched, VHOST_15_NEXSIS_V3_TAG);
+        assertVhostEquals(matched, VHOST_15_NEXSIS_VACTIVE_TAG);
         assertQueueEquals(matched, HUB_NEXSIS_USER_CLIENT_ID + ".message");
         assertTrue(Utils.isMessageOfType(matched, "createCase"));
 
-        String ackDistributionId = sendAck(VHOST_15_NEXSIS_V3_TAG, NEXSIS_SHOVEL_ROUTING_KEY, SAMU1_V1_ID, distributionId);
+        String ackDistributionId = sendAck(VHOST_15_NEXSIS_VACTIVE_TAG, NEXSIS_SHOVEL_ROUTING_KEY, SAMU1_V1_ID, distributionId);
 
         MessageDTO matchedAck = awaitMessage(ackDistributionId);
 
@@ -74,11 +76,11 @@ class SamuFireTest extends AMQPTestSupport {
         MessageDTO matched = awaitMessage(distributionId);
 
         assertNotNull(matched, "Message " + distributionId + " not received within " + RECEIVE_TIMEOUT_SECS + "s");
-        assertVhostEquals(matched, VHOST_15_NEXSIS_V3_TAG);
+        assertVhostEquals(matched, VHOST_15_NEXSIS_VACTIVE_TAG);
         assertQueueEquals(matched, HUB_NEXSIS_USER_CLIENT_ID + ".message");
         assertTrue(Utils.isMessageOfType(matched, "createCase"));
 
-        String ackDistributionId = sendAck(VHOST_15_NEXSIS_V3_TAG, NEXSIS_SHOVEL_ROUTING_KEY, SAMU1_V3_ID, distributionId);
+        String ackDistributionId = sendAck(VHOST_15_NEXSIS_VACTIVE_TAG, NEXSIS_SHOVEL_ROUTING_KEY, SAMU1_V3_ID, distributionId);
 
         MessageDTO matchedAck = awaitMessage(ackDistributionId);
 
@@ -105,11 +107,11 @@ class SamuFireTest extends AMQPTestSupport {
         MessageDTO matched = awaitMessage(distributionId);
 
         assertNotNull(matched, "Message " + distributionId + " not received within " + RECEIVE_TIMEOUT_SECS + "s");
-        assertVhostEquals(matched, VHOST_15_NEXSIS_V3_TAG);
+        assertVhostEquals(matched, VHOST_15_NEXSIS_VACTIVE_TAG);
         assertQueueEquals(matched, HUB_NEXSIS_USER_CLIENT_ID + ".message");
         assertTrue(Utils.isMessageOfType(matched, "createCase"));
 
-        String ackDistributionId = sendAck(VHOST_15_NEXSIS_V3_TAG, NEXSIS_SHOVEL_ROUTING_KEY, SAMU2_V3_ID, distributionId);
+        String ackDistributionId = sendAck(VHOST_15_NEXSIS_VACTIVE_TAG, NEXSIS_SHOVEL_ROUTING_KEY, SAMU2_V3_ID, distributionId);
 
         MessageDTO matchedAck = awaitMessage(ackDistributionId);
 
@@ -131,7 +133,7 @@ class SamuFireTest extends AMQPTestSupport {
         String edxlJson = new MessageBuilder().buildMessage(
                 useCase, distributionId, TNR_SDIS_CLIENT_ID, SAMU1_V3_ID);
 
-        sendMessage(VHOST_15_NEXSIS_V3_TAG, NEXSIS_SHOVEL_ROUTING_KEY, edxlJson);
+        sendMessage(VHOST_15_NEXSIS_VACTIVE_TAG, NEXSIS_SHOVEL_ROUTING_KEY, edxlJson);
 
         MessageDTO matched = awaitMessage(distributionId);
 
@@ -147,7 +149,7 @@ class SamuFireTest extends AMQPTestSupport {
         String referencedDistributionID = Utils.getReferencedDistributionID(matchedAck);
 
         assertNotNull(matchedAck, "Ack " + ackDistributionId + " not received within " + RECEIVE_TIMEOUT_SECS + "s");
-        assertVhostEquals(matchedAck, VHOST_15_NEXSIS_V3_TAG);
+        assertVhostEquals(matchedAck, VHOST_15_NEXSIS_VACTIVE_TAG);
         assertQueueEquals(matchedAck, HUB_NEXSIS_USER_CLIENT_ID + ".ack");
         assertEquals(distributionId, referencedDistributionID);
     }
@@ -162,7 +164,7 @@ class SamuFireTest extends AMQPTestSupport {
         String edxlJson = new MessageBuilder().buildMessage(
                 useCase, distributionId, TNR_SDIS_CLIENT_ID, SAMU1_V1_ID);
 
-        sendMessage(VHOST_15_NEXSIS_V3_TAG, NEXSIS_SHOVEL_ROUTING_KEY, edxlJson);
+        sendMessage(VHOST_15_NEXSIS_VACTIVE_TAG, NEXSIS_SHOVEL_ROUTING_KEY, edxlJson);
 
         MessageDTO matched = awaitMessage(distributionId);
 
@@ -178,7 +180,7 @@ class SamuFireTest extends AMQPTestSupport {
         String referencedDistributionID = Utils.getReferencedDistributionID(matchedAck);
 
         assertNotNull(matchedAck, "Ack " + ackDistributionId + " not received within " + RECEIVE_TIMEOUT_SECS + "s");
-        assertVhostEquals(matchedAck, VHOST_15_NEXSIS_V3_TAG);
+        assertVhostEquals(matchedAck, VHOST_15_NEXSIS_VACTIVE_TAG);
         assertQueueEquals(matchedAck, HUB_NEXSIS_USER_CLIENT_ID + ".ack");
         assertEquals(distributionId, referencedDistributionID);
     }
@@ -193,7 +195,7 @@ class SamuFireTest extends AMQPTestSupport {
         String edxlJson = new MessageBuilder().buildMessage(
                 useCase, distributionId, TNR_SDIS_CLIENT_ID, SAMU2_V3_ID);
 
-        sendMessage(VHOST_15_NEXSIS_V3_TAG, NEXSIS_SHOVEL_ROUTING_KEY, edxlJson);
+        sendMessage(VHOST_15_NEXSIS_VACTIVE_TAG, NEXSIS_SHOVEL_ROUTING_KEY, edxlJson);
 
         MessageDTO matched = awaitMessage(distributionId);
 
@@ -209,7 +211,7 @@ class SamuFireTest extends AMQPTestSupport {
         String referencedDistributionID = Utils.getReferencedDistributionID(matchedAck);
 
         assertNotNull(matchedAck, "Ack " + ackDistributionId + " not received within " + RECEIVE_TIMEOUT_SECS + "s");
-        assertVhostEquals(matchedAck, VHOST_15_NEXSIS_V3_TAG);
+        assertVhostEquals(matchedAck, VHOST_15_NEXSIS_VACTIVE_TAG);
         assertQueueEquals(matchedAck, HUB_NEXSIS_USER_CLIENT_ID + ".ack");
         assertEquals(distributionId, referencedDistributionID);
     }


### PR DESCRIPTION
## 🔎 Détails

Mise à jour des TNR pour ajouter le support du vhost vactive.

## Validation

Se rendre sur https://github.com/ansforge/SAMU-Hub-Sante/actions/workflows/run-tnr.yaml

1. Lancer le workflow sur environnement qualification et branche `main` -> observer le fail des TNR

2. Relancer le meme workflow cette fois sur la branche `fix/tnr-use-vactive` -> observer le success des TNR