### PR TITLE
Feat/dispatcher/add client config bean

### DIFF
--- a/hub/.gitignore
+++ b/hub/.gitignore
@@ -27,6 +27,7 @@ out/
 !**/src/test/**/out/
 **/application-bbo.properties
 **/client.preferences.csv
+**/clients.yaml
 dispatcher/gradle.properties
 
 ### NetBeans ###

--- a/hub/.gitignore
+++ b/hub/.gitignore
@@ -27,7 +27,7 @@ out/
 !**/src/test/**/out/
 **/application-bbo.properties
 **/client.preferences.csv
-**/clients.yaml
+**/src/main/resources/clients.yaml
 dispatcher/gradle.properties
 
 ### NetBeans ###

--- a/hub/dispatcher/src/main/java/com/hubsante/hub/exception/ClientConfigurationException.java
+++ b/hub/dispatcher/src/main/java/com/hubsante/hub/exception/ClientConfigurationException.java
@@ -13,20 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hubsante.hub.model;
+package com.hubsante.hub.exception;
 
-import java.util.List;
+public class ClientConfigurationException extends RuntimeException {
 
-public record ClientProperties(
-        String clientId,
-        boolean useXml,
-        boolean directCisu,
-        String editor,
-        List<PerimeterDefinition> perimeters,
-        List<String> inhibitedUseCases) {
+    public ClientConfigurationException(String message) {
+        super(message);
+    }
 
-    public ClientProperties {
-        perimeters = perimeters == null ? List.of() : List.copyOf(perimeters);
-        inhibitedUseCases = inhibitedUseCases == null ? List.of() : List.copyOf(inhibitedUseCases);
+    public ClientConfigurationException(String clientId, String message) {
+        super("Client '" + clientId + "': " + message);
     }
 }

--- a/hub/dispatcher/src/main/java/com/hubsante/hub/exception/ClientConfigurationException.java
+++ b/hub/dispatcher/src/main/java/com/hubsante/hub/exception/ClientConfigurationException.java
@@ -20,8 +20,4 @@ public class ClientConfigurationException extends RuntimeException {
     public ClientConfigurationException(String message) {
         super(message);
     }
-
-    public ClientConfigurationException(String clientId, String message) {
-        super("Client '" + clientId + "': " + message);
-    }
 }

--- a/hub/dispatcher/src/main/java/com/hubsante/hub/model/ClientProperties.java
+++ b/hub/dispatcher/src/main/java/com/hubsante/hub/model/ClientProperties.java
@@ -1,0 +1,11 @@
+package com.hubsante.hub.model;
+
+import java.util.List;
+
+public record ClientProperties(
+        String clientId,
+        boolean useXml,         
+        boolean directCisu, String editor,
+        List<PerimeterDefinition> perimeters,
+        List<String> inhibitedUseCases){
+}

--- a/hub/dispatcher/src/main/java/com/hubsante/hub/model/ClientProperties.java
+++ b/hub/dispatcher/src/main/java/com/hubsante/hub/model/ClientProperties.java
@@ -1,11 +1,26 @@
+/**
+ * Copyright © 2023-2026 Agence du Numerique en Sante (ANS)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hubsante.hub.model;
 
 import java.util.List;
 
 public record ClientProperties(
         String clientId,
-        boolean useXml,         
-        boolean directCisu, String editor,
+        boolean useXml,
+        boolean directCisu,
+        String editor,
         List<PerimeterDefinition> perimeters,
-        List<String> inhibitedUseCases){
-}
+        List<String> inhibitedUseCases) {}

--- a/hub/dispatcher/src/main/java/com/hubsante/hub/model/ClientProperties.java
+++ b/hub/dispatcher/src/main/java/com/hubsante/hub/model/ClientProperties.java
@@ -26,7 +26,6 @@ public record ClientProperties(
         List<String> inhibitedUseCases) {
 
     public ClientProperties {
-        perimeters = perimeters == null ? List.of() : List.copyOf(perimeters);
         inhibitedUseCases = inhibitedUseCases == null ? List.of() : List.copyOf(inhibitedUseCases);
     }
 }

--- a/hub/dispatcher/src/main/java/com/hubsante/hub/model/PerimeterDefinition.java
+++ b/hub/dispatcher/src/main/java/com/hubsante/hub/model/PerimeterDefinition.java
@@ -1,8 +1,20 @@
+/**
+ * Copyright © 2023-2026 Agence du Numerique en Sante (ANS)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hubsante.hub.model;
 
 import java.util.List;
 
-public record PerimeterDefinition(
-        String name,
-        List<String> versions) {
-}
+public record PerimeterDefinition(String name, List<String> versions) {}

--- a/hub/dispatcher/src/main/java/com/hubsante/hub/model/PerimeterDefinition.java
+++ b/hub/dispatcher/src/main/java/com/hubsante/hub/model/PerimeterDefinition.java
@@ -1,0 +1,8 @@
+package com.hubsante.hub.model;
+
+import java.util.List;
+
+public record PerimeterDefinition(
+        String name,
+        List<String> versions) {
+}

--- a/hub/dispatcher/src/main/java/com/hubsante/hub/service/ClientPropertiesRegistry.java
+++ b/hub/dispatcher/src/main/java/com/hubsante/hub/service/ClientPropertiesRegistry.java
@@ -46,7 +46,7 @@ public class ClientPropertiesRegistry {
 
             Properties props = factory.getObject();
             if (props == null) {
-                throw new ClientConfigurationException("clients.yaml is empty");
+                throw new ClientConfigurationException("clients configuration file is empty");
             }
 
             var env = new StandardEnvironment();
@@ -57,7 +57,10 @@ public class ClientPropertiesRegistry {
 
             List<ClientProperties> clients =
                     binder.bind("clients", Bindable.listOf(ClientProperties.class))
-                            .orElse(List.of());
+                            .orElseThrow(
+                                    () ->
+                                            new ClientConfigurationException(
+                                                    "Missing 'clients' block in clients configuration file"));
 
             validateClients(clients);
 

--- a/hub/dispatcher/src/main/java/com/hubsante/hub/service/ClientPropertiesRegistry.java
+++ b/hub/dispatcher/src/main/java/com/hubsante/hub/service/ClientPropertiesRegistry.java
@@ -1,6 +1,26 @@
+/**
+ * Copyright © 2023-2026 Agence du Numerique en Sante (ANS)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hubsante.hub.service;
 
 import com.hubsante.hub.model.ClientProperties;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
 import org.springframework.boot.context.properties.bind.Bindable;
@@ -10,19 +30,12 @@ import org.springframework.core.env.StandardEnvironment;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
 @Component
 public class ClientPropertiesRegistry {
     private Map<String, ClientProperties> clientsById = Map.of();
 
-    public ClientPropertiesRegistry(
-            @Value("${client.configuration.file}") Resource resource
-    ) throws Exception {
+    public ClientPropertiesRegistry(@Value("${client.configuration.file}") Resource resource)
+            throws Exception {
         load(resource);
     }
 
@@ -42,16 +55,12 @@ public class ClientPropertiesRegistry {
 
         Binder binder = Binder.get(env);
 
-        List<ClientProperties> clients = binder.bind(
-                "clients",
-                Bindable.listOf(ClientProperties.class)
-        ).orElse(List.of());
+        List<ClientProperties> clients =
+                binder.bind("clients", Bindable.listOf(ClientProperties.class)).orElse(List.of());
 
-        this.clientsById = clients.stream()
-                .collect(Collectors.toMap(
-                        ClientProperties::clientId,
-                        Function.identity()
-                ));
+        this.clientsById =
+                clients.stream()
+                        .collect(Collectors.toMap(ClientProperties::clientId, Function.identity()));
     }
 
     public ClientProperties get(String clientId) {

--- a/hub/dispatcher/src/main/java/com/hubsante/hub/service/ClientPropertiesRegistry.java
+++ b/hub/dispatcher/src/main/java/com/hubsante/hub/service/ClientPropertiesRegistry.java
@@ -82,22 +82,26 @@ public class ClientPropertiesRegistry {
                 throw new ClientConfigurationException("ClientId is missing in configuration");
             }
 
-            if (client.perimeters() != null) {
-                for (PerimeterDefinition perimeter : client.perimeters()) {
+            if (client.perimeters() == null || client.perimeters().isEmpty()) {
+                throw new ClientConfigurationException("At least one perimeter must be configured");
+            }
 
-                    try {
-                        validatePerimeter(client.clientId(), perimeter);
-                    } catch (IllegalArgumentException e) {
-                        throw new ClientConfigurationException(
-                                client.clientId(),
-                                "Invalid perimeter '" + perimeter.name() + "': " + e.getMessage());
-                    }
+            for (PerimeterDefinition perimeter : client.perimeters()) {
+                try {
+                    validatePerimeter(perimeter);
+                } catch (IllegalArgumentException e) {
+                    throw new ClientConfigurationException(
+                            client.clientId(),
+                            "Invalid perimeter configuration for client "
+                                    + client.clientId()
+                                    + ": "
+                                    + e.getMessage());
                 }
             }
         }
     }
 
-    private void validatePerimeter(String clientId, PerimeterDefinition perimeter) {
+    private void validatePerimeter(PerimeterDefinition perimeter) {
 
         if (perimeter.name() == null || perimeter.name().isBlank()) {
             throw new IllegalArgumentException("name must not be blank");

--- a/hub/dispatcher/src/main/java/com/hubsante/hub/service/ClientPropertiesRegistry.java
+++ b/hub/dispatcher/src/main/java/com/hubsante/hub/service/ClientPropertiesRegistry.java
@@ -1,0 +1,60 @@
+package com.hubsante.hub.service;
+
+import com.hubsante.hub.model.ClientProperties;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.core.env.PropertiesPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+public class ClientPropertiesRegistry {
+    private Map<String, ClientProperties> clientsById = Map.of();
+
+    public ClientPropertiesRegistry(
+            @Value("${client.configuration.file}") Resource resource
+    ) throws Exception {
+        load(resource);
+    }
+
+    private void load(Resource resource) throws Exception {
+
+        YamlPropertiesFactoryBean factory = new YamlPropertiesFactoryBean();
+        factory.setResources(resource);
+
+        Properties props = factory.getObject();
+        if (props == null) {
+            throw new IllegalStateException("clients.yaml is empty");
+        }
+
+        var env = new StandardEnvironment();
+        var ps = new PropertiesPropertySource("clients", props);
+        env.getPropertySources().addFirst(ps);
+
+        Binder binder = Binder.get(env);
+
+        List<ClientProperties> clients = binder.bind(
+                "clients",
+                Bindable.listOf(ClientProperties.class)
+        ).orElse(List.of());
+
+        this.clientsById = clients.stream()
+                .collect(Collectors.toMap(
+                        ClientProperties::clientId,
+                        Function.identity()
+                ));
+    }
+
+    public ClientProperties get(String clientId) {
+        return clientsById.get(clientId);
+    }
+}

--- a/hub/dispatcher/src/main/java/com/hubsante/hub/service/ClientPropertiesRegistry.java
+++ b/hub/dispatcher/src/main/java/com/hubsante/hub/service/ClientPropertiesRegistry.java
@@ -15,7 +15,9 @@
  */
 package com.hubsante.hub.service;
 
+import com.hubsante.hub.exception.ClientConfigurationException;
 import com.hubsante.hub.model.ClientProperties;
+import com.hubsante.hub.model.PerimeterDefinition;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -40,30 +42,79 @@ public class ClientPropertiesRegistry {
     }
 
     private void load(Resource resource) throws Exception {
+        try {
+            YamlPropertiesFactoryBean factory = new YamlPropertiesFactoryBean();
+            factory.setResources(resource);
 
-        YamlPropertiesFactoryBean factory = new YamlPropertiesFactoryBean();
-        factory.setResources(resource);
+            Properties props = factory.getObject();
+            if (props == null) {
+                throw new IllegalStateException("clients.yaml is empty");
+            }
 
-        Properties props = factory.getObject();
-        if (props == null) {
-            throw new IllegalStateException("clients.yaml is empty");
+            var env = new StandardEnvironment();
+            var ps = new PropertiesPropertySource("clients", props);
+            env.getPropertySources().addFirst(ps);
+
+            Binder binder = Binder.get(env);
+
+            List<ClientProperties> clients =
+                    binder.bind("clients", Bindable.listOf(ClientProperties.class))
+                            .orElse(List.of());
+
+            validateClients(clients);
+
+            this.clientsById =
+                    clients.stream()
+                            .collect(
+                                    Collectors.toMap(
+                                            ClientProperties::clientId, Function.identity()));
+
+        } catch (Exception e) {
+            throw new ClientConfigurationException("Failed to load clients.yaml" + e.getMessage());
+        }
+    }
+
+    private void validateClients(List<ClientProperties> clients) {
+
+        for (ClientProperties client : clients) {
+
+            if (client.clientId() == null || client.clientId().isBlank()) {
+                throw new ClientConfigurationException("ClientId is missing in configuration");
+            }
+
+            if (client.perimeters() != null) {
+                for (PerimeterDefinition perimeter : client.perimeters()) {
+
+                    try {
+                        validatePerimeter(client.clientId(), perimeter);
+                    } catch (IllegalArgumentException e) {
+                        throw new ClientConfigurationException(
+                                client.clientId(),
+                                "Invalid perimeter '" + perimeter.name() + "': " + e.getMessage());
+                    }
+                }
+            }
+        }
+    }
+
+    private void validatePerimeter(String clientId, PerimeterDefinition perimeter) {
+
+        if (perimeter.name() == null || perimeter.name().isBlank()) {
+            throw new IllegalArgumentException("name must not be blank");
         }
 
-        var env = new StandardEnvironment();
-        var ps = new PropertiesPropertySource("clients", props);
-        env.getPropertySources().addFirst(ps);
-
-        Binder binder = Binder.get(env);
-
-        List<ClientProperties> clients =
-                binder.bind("clients", Bindable.listOf(ClientProperties.class)).orElse(List.of());
-
-        this.clientsById =
-                clients.stream()
-                        .collect(Collectors.toMap(ClientProperties::clientId, Function.identity()));
+        if (perimeter.versions() == null || perimeter.versions().isEmpty()) {
+            throw new IllegalArgumentException("versions must not be empty");
+        }
     }
 
     public ClientProperties get(String clientId) {
-        return clientsById.get(clientId);
+        ClientProperties clientProperties = clientsById.get(clientId);
+
+        if (clientProperties == null) {
+            throw new IllegalStateException("client " + clientId + " is not configured");
+        }
+
+        return clientProperties;
     }
 }

--- a/hub/dispatcher/src/main/java/com/hubsante/hub/service/ClientPropertiesRegistry.java
+++ b/hub/dispatcher/src/main/java/com/hubsante/hub/service/ClientPropertiesRegistry.java
@@ -18,9 +18,7 @@ package com.hubsante.hub.service;
 import com.hubsante.hub.exception.ClientConfigurationException;
 import com.hubsante.hub.model.ClientProperties;
 import com.hubsante.hub.model.PerimeterDefinition;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Value;
@@ -48,7 +46,7 @@ public class ClientPropertiesRegistry {
 
             Properties props = factory.getObject();
             if (props == null) {
-                throw new IllegalStateException("clients.yaml is empty");
+                throw new ClientConfigurationException("clients.yaml is empty");
             }
 
             var env = new StandardEnvironment();
@@ -70,53 +68,74 @@ public class ClientPropertiesRegistry {
                                             ClientProperties::clientId, Function.identity()));
 
         } catch (Exception e) {
-            throw new ClientConfigurationException("Failed to load clients.yaml" + e.getMessage());
+            throw new ClientConfigurationException(e.getMessage());
         }
     }
 
     private void validateClients(List<ClientProperties> clients) {
+        Map<String, List<String>> errorsByClient = new LinkedHashMap<>();
 
         for (ClientProperties client : clients) {
+            List<String> errors = new ArrayList<>();
 
             if (client.clientId() == null || client.clientId().isBlank()) {
-                throw new ClientConfigurationException("ClientId is missing in configuration");
+                errors.add("ClientId is missing in configuration");
             }
 
             if (client.perimeters() == null || client.perimeters().isEmpty()) {
-                throw new ClientConfigurationException("At least one perimeter must be configured");
+                errors.add("At least one perimeter must be configured");
             }
 
-            for (PerimeterDefinition perimeter : client.perimeters()) {
-                try {
-                    validatePerimeter(perimeter);
-                } catch (IllegalArgumentException e) {
-                    throw new ClientConfigurationException(
-                            client.clientId(),
-                            "Invalid perimeter configuration for client "
-                                    + client.clientId()
-                                    + ": "
-                                    + e.getMessage());
+            if (client.perimeters() != null) {
+                for (PerimeterDefinition perimeter : client.perimeters()) {
+                    try {
+                        validatePerimeter(perimeter);
+                    } catch (IllegalArgumentException e) {
+                        errors.add(e.getMessage());
+                    }
                 }
             }
+
+            if (!errors.isEmpty()) {
+                errorsByClient.put(client.clientId(), errors);
+            }
+        }
+
+        if (!errorsByClient.isEmpty()) {
+            throw buildException(errorsByClient);
         }
     }
 
     private void validatePerimeter(PerimeterDefinition perimeter) {
-
         if (perimeter.name() == null || perimeter.name().isBlank()) {
-            throw new IllegalArgumentException("name must not be blank");
+            throw new IllegalArgumentException("Perimeter name must not be blank");
         }
 
         if (perimeter.versions() == null || perimeter.versions().isEmpty()) {
-            throw new IllegalArgumentException("versions must not be empty");
+            throw new IllegalArgumentException("Perimeter versions must not be empty");
         }
+    }
+
+    private ClientConfigurationException buildException(Map<String, List<String>> errorsByClient) {
+
+        StringBuilder sb = new StringBuilder("Invalid clients configuration:\n");
+
+        errorsByClient.forEach(
+                (clientId, errors) -> {
+                    sb.append("\nClient: ").append(clientId).append("\n");
+                    for (String error : errors) {
+                        sb.append("  - ").append(error).append("\n");
+                    }
+                });
+
+        return new ClientConfigurationException(sb.toString());
     }
 
     public ClientProperties get(String clientId) {
         ClientProperties clientProperties = clientsById.get(clientId);
 
         if (clientProperties == null) {
-            throw new IllegalStateException("client " + clientId + " is not configured");
+            throw new ClientConfigurationException("client " + clientId + " is not configured");
         }
 
         return clientProperties;

--- a/hub/dispatcher/src/main/resources/application.properties
+++ b/hub/dispatcher/src/main/resources/application.properties
@@ -21,6 +21,7 @@ app.model-version=${APP_MODEL_VERSION:unknown}
 
 client.preferences.file=file:/config/client.preferences.csv
 supported.messages.file=file:/config/supported.messages.csv
+client.configuration.file=file:/config/clients.yaml
 # dispatcher.default.ttl needs to be syncd with RabbitMQ conf :
 # expressed in seconds for readability and use in code,
 # should match the message TTL applied to all client queues (which is in milliseconds)

--- a/hub/dispatcher/src/main/resources/clients.template.yaml
+++ b/hub/dispatcher/src/main/resources/clients.template.yaml
@@ -1,0 +1,35 @@
+clients:
+  - client_id: fr.health.test.samu-v1
+    common_name: fr.health.test.samu-v1.fr
+    perimeters:
+      - name: '15-15'
+        versions:
+          - '1.5'
+    editor: ANS
+    inhibitedUseCases:
+      - 'ResourcesInfoCisuWrapper'
+  - client_id: fr.health.test.samu-v3
+    common_name: fr.health.test.samu-v3.fr
+    perimeters:
+      - name: '15-15'
+        versions:
+          - '2.1'
+    editor: ANS
+  - client_id: fr.health.test.samu-v3-direct-cisu
+    common_name: fr.health.test.samu-v3-direct-cisu.fr
+    perimeters:
+      - name: '15-15'
+        versions:
+          - '2.1'
+      - name: '15-nexsis'
+        versions:
+          - '1.9'
+    editor: ANS
+    directCisu: true
+  - client_id: fr.fire.nxsis.sdisZ
+    common_name: fr.fire.nexsis.sdisZ.fr
+    perimeters:
+      - name: '15-nexsis'
+        versions:
+          - '1.9'
+    editor: ANS

--- a/hub/dispatcher/src/test/java/com/hubsante/hub/service/ClientPropertiesRegistryTest.java
+++ b/hub/dispatcher/src/test/java/com/hubsante/hub/service/ClientPropertiesRegistryTest.java
@@ -68,7 +68,7 @@ public class ClientPropertiesRegistryTest {
         ClientProperties samuV1Properties = clientPropertiesRegistry.get("fr.health.test.samu-v1");
         ClientProperties samuV3Properties = clientPropertiesRegistry.get("fr.health.test.samu-v3");
 
-        assertThrows(IllegalStateException.class, () -> clientPropertiesRegistry.get("unknown"));
+        assertThrows(ClientConfigurationException.class, () -> clientPropertiesRegistry.get("unknown"));
 
         List<String> samuV1InhibitedMessages = samuV1Properties.inhibitedUseCases();
         assertNotNull(samuV1InhibitedMessages);
@@ -77,28 +77,45 @@ public class ClientPropertiesRegistryTest {
 
     @Test
     void should_fail_when_loading_invalid_yaml() {
+        String exceptionPrefix = "Invalid clients configuration:\n\n";
 
+        // perimeter wth no name
         Resource missingPerimeterNameYaml =
                 new ClassPathResource("config/invalid-clients-missing-perimeter-name.yaml");
 
-        assertThrows(
-                ClientConfigurationException.class,
-                () -> {
-                    new ClientPropertiesRegistry(missingPerimeterNameYaml);
-                });
+        ClientConfigurationException missingPerimeterNameException =
+                assertThrows(
+                        ClientConfigurationException.class,
+                        () -> new ClientPropertiesRegistry(missingPerimeterNameYaml));
+        assertEquals(
+                exceptionPrefix
+                        + "Client: fr.health.test.samu-v1\n  - Perimeter name must not be blank\n",
+                missingPerimeterNameException.getMessage());
 
+        // perimeter without versions
         Resource missingPerimeterVersionsYaml =
                 new ClassPathResource("config/invalid-clients-missing-perimeter-versions.yaml");
 
-        assertThrows(
-                ClientConfigurationException.class,
-                () -> new ClientPropertiesRegistry(missingPerimeterVersionsYaml));
+        ClientConfigurationException missingPerimeterVersionsException =
+                assertThrows(
+                        ClientConfigurationException.class,
+                        () -> new ClientPropertiesRegistry(missingPerimeterVersionsYaml));
+        assertEquals(
+                exceptionPrefix
+                        + "Client: fr.health.test.samu-v1\n  - Perimeter versions must not be empty\n",
+                missingPerimeterVersionsException.getMessage());
 
+        // no perimeter at all
         Resource missingPerimetersYaml =
-                new ClassPathResource("config/invalid-clients-missing-perimeters.yaml");
+                new ClassPathResource("config/invalid-clients-no-perimeters.yaml");
 
-        assertThrows(
-                ClientConfigurationException.class,
-                () -> new ClientPropertiesRegistry(missingPerimetersYaml));
+        ClientConfigurationException missingPerimeterBlock =
+                assertThrows(
+                        ClientConfigurationException.class,
+                        () -> new ClientPropertiesRegistry(missingPerimetersYaml));
+        assertEquals(
+                exceptionPrefix
+                        + "Client: fr.health.test.samu-v1\n  - At least one perimeter must be configured\n",
+                missingPerimeterBlock.getMessage());
     }
 }

--- a/hub/dispatcher/src/test/java/com/hubsante/hub/service/ClientPropertiesRegistryTest.java
+++ b/hub/dispatcher/src/test/java/com/hubsante/hub/service/ClientPropertiesRegistryTest.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright © 2023-2026 Agence du Numerique en Sante (ANS)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hubsante.hub.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.hubsante.hub.HubApplication;
+import com.hubsante.hub.exception.ClientConfigurationException;
+import com.hubsante.hub.model.ClientProperties;
+import java.util.List;
+import java.util.Objects;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.amqp.rabbit.test.context.SpringRabbitTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+@SpringBootTest
+@ContextConfiguration(classes = HubApplication.class)
+@SpringRabbitTest
+public class ClientPropertiesRegistryTest {
+
+    static ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+    @Autowired private ClientPropertiesRegistry clientPropertiesRegistry;
+
+    @DynamicPropertySource
+    static void registerPgProperties(DynamicPropertyRegistry propertiesRegistry) {
+        propertiesRegistry.add(
+                "supported.messages.file",
+                () ->
+                        Objects.requireNonNull(
+                                classLoader.getResource("config/supported.messages.csv")));
+        propertiesRegistry.add(
+                "client.preferences.file",
+                () ->
+                        Objects.requireNonNull(
+                                classLoader.getResource("config/client.preferences.csv")));
+        propertiesRegistry.add(
+                "client.configuration.file",
+                () -> Objects.requireNonNull(classLoader.getResource("config/clients.yaml")));
+        propertiesRegistry.add("hubsante.default.message.ttl", () -> 5);
+        propertiesRegistry.add("spring.rabbitmq.virtual-host", () -> "15-15_v2.1");
+    }
+
+    @Test
+    @DisplayName("should load Client configuration")
+    public void shouldLoadClientConfiguration() {
+        assertNotNull(this.clientPropertiesRegistry);
+
+        ClientProperties samuV1Properties = clientPropertiesRegistry.get("fr.health.test.samu-v1");
+        ClientProperties samuV3Properties = clientPropertiesRegistry.get("fr.health.test.samu-v3");
+
+        assertThrows(IllegalStateException.class, () -> clientPropertiesRegistry.get("unknown"));
+
+        List<String> samuV1InhibitedMessages = samuV1Properties.inhibitedUseCases();
+        assertNotNull(samuV1InhibitedMessages);
+        assertEquals(List.of("ResourcesInfoCisuWrapper"), samuV1InhibitedMessages);
+    }
+
+    @Test
+    void should_fail_when_loading_invalid_yaml() {
+
+        Resource missingPerimeterNameYaml =
+                new ClassPathResource("config/invalid-clients-missing-perimeter-name.yaml");
+
+        assertThrows(
+                ClientConfigurationException.class,
+                () -> {
+                    new ClientPropertiesRegistry(missingPerimeterNameYaml);
+                });
+
+        Resource missingPerimeterVersionsYaml =
+                new ClassPathResource("config/invalid-clients-missing-perimeter-versions.yaml");
+
+        assertThrows(
+                ClientConfigurationException.class,
+                () -> new ClientPropertiesRegistry(missingPerimeterVersionsYaml));
+    }
+}

--- a/hub/dispatcher/src/test/java/com/hubsante/hub/service/ClientPropertiesRegistryTest.java
+++ b/hub/dispatcher/src/test/java/com/hubsante/hub/service/ClientPropertiesRegistryTest.java
@@ -93,5 +93,12 @@ public class ClientPropertiesRegistryTest {
         assertThrows(
                 ClientConfigurationException.class,
                 () -> new ClientPropertiesRegistry(missingPerimeterVersionsYaml));
+
+        Resource missingPerimetersYaml =
+                new ClassPathResource("config/invalid-clients-missing-perimeters.yaml");
+
+        assertThrows(
+                ClientConfigurationException.class,
+                () -> new ClientPropertiesRegistry(missingPerimetersYaml));
     }
 }

--- a/hub/dispatcher/src/test/java/com/hubsante/hub/service/ClientPropertiesRegistryTest.java
+++ b/hub/dispatcher/src/test/java/com/hubsante/hub/service/ClientPropertiesRegistryTest.java
@@ -68,7 +68,8 @@ public class ClientPropertiesRegistryTest {
         ClientProperties samuV1Properties = clientPropertiesRegistry.get("fr.health.test.samu-v1");
         ClientProperties samuV3Properties = clientPropertiesRegistry.get("fr.health.test.samu-v3");
 
-        assertThrows(ClientConfigurationException.class, () -> clientPropertiesRegistry.get("unknown"));
+        assertThrows(
+                ClientConfigurationException.class, () -> clientPropertiesRegistry.get("unknown"));
 
         List<String> samuV1InhibitedMessages = samuV1Properties.inhibitedUseCases();
         assertNotNull(samuV1InhibitedMessages);

--- a/hub/dispatcher/src/test/java/com/hubsante/hub/service/DispatcherTest.java
+++ b/hub/dispatcher/src/test/java/com/hubsante/hub/service/DispatcherTest.java
@@ -126,6 +126,10 @@ public class DispatcherTest {
                 () ->
                         Objects.requireNonNull(
                                 classLoader.getResource("config/client.preferences.csv")));
+        propertiesRegistry.add(
+                "client.configuration.file",
+                () -> Objects.requireNonNull(classLoader.getResource("config/clients.yaml"))
+        );
         propertiesRegistry.add("hubsante.default.message.ttl", () -> 5);
         propertiesRegistry.add("spring.rabbitmq.virtual-host", () -> "15-15_v2.1");
     }

--- a/hub/dispatcher/src/test/java/com/hubsante/hub/service/DispatcherTest.java
+++ b/hub/dispatcher/src/test/java/com/hubsante/hub/service/DispatcherTest.java
@@ -128,8 +128,7 @@ public class DispatcherTest {
                                 classLoader.getResource("config/client.preferences.csv")));
         propertiesRegistry.add(
                 "client.configuration.file",
-                () -> Objects.requireNonNull(classLoader.getResource("config/clients.yaml"))
-        );
+                () -> Objects.requireNonNull(classLoader.getResource("config/clients.yaml")));
         propertiesRegistry.add("hubsante.default.message.ttl", () -> 5);
         propertiesRegistry.add("spring.rabbitmq.virtual-host", () -> "15-15_v2.1");
     }

--- a/hub/dispatcher/src/test/java/com/hubsante/hub/service/HubApplicationTests.java
+++ b/hub/dispatcher/src/test/java/com/hubsante/hub/service/HubApplicationTests.java
@@ -57,6 +57,10 @@ class HubApplicationTests {
                                     + Thread.currentThread()
                                             .getContextClassLoader()
                                             .getResource("config/client.preferences.csv"),
+                            "client.configuration.file="
+                                    + Thread.currentThread()
+                                            .getContextClassLoader()
+                                            .getResource("config/clients.yaml"),
                             "supported.messages.file="
                                     + Thread.currentThread()
                                             .getContextClassLoader()

--- a/hub/dispatcher/src/test/java/com/hubsante/hub/service/LogIntegrityTest.java
+++ b/hub/dispatcher/src/test/java/com/hubsante/hub/service/LogIntegrityTest.java
@@ -88,8 +88,7 @@ public class LogIntegrityTest {
                                 classLoader.getResource("config/client.preferences.csv")));
         propertiesRegistry.add(
                 "client.configuration.file",
-                () -> Objects.requireNonNull(classLoader.getResource("config/clients.yaml"))
-        );
+                () -> Objects.requireNonNull(classLoader.getResource("config/clients.yaml")));
         propertiesRegistry.add("dispatcher.default.ttl", () -> 600);
         propertiesRegistry.add("spring.rabbitmq.virtual-host", () -> "15-15_v2.1");
     }

--- a/hub/dispatcher/src/test/java/com/hubsante/hub/service/LogIntegrityTest.java
+++ b/hub/dispatcher/src/test/java/com/hubsante/hub/service/LogIntegrityTest.java
@@ -86,6 +86,10 @@ public class LogIntegrityTest {
                 () ->
                         Objects.requireNonNull(
                                 classLoader.getResource("config/client.preferences.csv")));
+        propertiesRegistry.add(
+                "client.configuration.file",
+                () -> Objects.requireNonNull(classLoader.getResource("config/clients.yaml"))
+        );
         propertiesRegistry.add("dispatcher.default.ttl", () -> 600);
         propertiesRegistry.add("spring.rabbitmq.virtual-host", () -> "15-15_v2.1");
     }

--- a/hub/dispatcher/src/test/java/com/hubsante/hub/service/RabbitIntegrationAbstract.java
+++ b/hub/dispatcher/src/test/java/com/hubsante/hub/service/RabbitIntegrationAbstract.java
@@ -139,7 +139,7 @@ public class RabbitIntegrationAbstract {
                                     + Thread.currentThread()
                                             .getContextClassLoader()
                                             .getResource("config/client.preferences.csv"),
-                            "client.configuration.file=" 
+                            "client.configuration.file="
                                     + Thread.currentThread()
                                             .getContextClassLoader()
                                             .getResource("config/clients.yaml"),

--- a/hub/dispatcher/src/test/java/com/hubsante/hub/service/RabbitIntegrationAbstract.java
+++ b/hub/dispatcher/src/test/java/com/hubsante/hub/service/RabbitIntegrationAbstract.java
@@ -139,6 +139,10 @@ public class RabbitIntegrationAbstract {
                                     + Thread.currentThread()
                                             .getContextClassLoader()
                                             .getResource("config/client.preferences.csv"),
+                            "client.configuration.file=" 
+                                    + Thread.currentThread()
+                                            .getContextClassLoader()
+                                            .getResource("config/clients.yaml"),
                             "supported.messages.file="
                                     + Thread.currentThread()
                                             .getContextClassLoader()

--- a/hub/dispatcher/src/test/resources/config/clients.yaml
+++ b/hub/dispatcher/src/test/resources/config/clients.yaml
@@ -1,0 +1,35 @@
+clients:
+  - client_id: fr.health.test.samu-v1
+    common_name: fr.health.test.samu-v1.fr
+    perimeters:
+      - name: '15-15'
+        versions:
+          - '1.5'
+    editor: ANS
+    inhibitedUseCases:
+      - 'ResourcesInfoCisuWrapper'
+  - client_id: fr.health.test.samu-v3
+    common_name: fr.health.test.samu-v3.fr
+    perimeters:
+      - name: '15-15'
+        versions:
+          - '2.1'
+    editor: ANS
+  - client_id: fr.health.test.samu-v3-direct-cisu
+    common_name: fr.health.test.samu-v3-direct-cisu.fr
+    perimeters:
+      - name: '15-15'
+        versions:
+          - '2.1'
+      - name: '15-nexsis'
+        versions:
+          - '1.9'
+    editor: ANS
+    directCisu: true
+  - client_id: fr.fire.nxsis.sdisZ
+    common_name: fr.fire.nexsis.sdisZ.fr
+    perimeters:
+      - name: '15-nexsis'
+        versions:
+          - '1.9'
+    editor: ANS

--- a/hub/dispatcher/src/test/resources/config/invalid-clients-missing-perimeter-name.yaml
+++ b/hub/dispatcher/src/test/resources/config/invalid-clients-missing-perimeter-name.yaml
@@ -1,0 +1,6 @@
+clients:
+  - client_id: fr.health.test.samu-v1
+    common_name: fr.health.test.samu-v1.fr
+    perimeters:
+      - name: '15-15'
+    editor: ANS

--- a/hub/dispatcher/src/test/resources/config/invalid-clients-missing-perimeter-name.yaml
+++ b/hub/dispatcher/src/test/resources/config/invalid-clients-missing-perimeter-name.yaml
@@ -2,5 +2,7 @@ clients:
   - client_id: fr.health.test.samu-v1
     common_name: fr.health.test.samu-v1.fr
     perimeters:
-      - name: '15-15'
+      - versions:
+          - '1.5'
+          - '2.1'
     editor: ANS

--- a/hub/dispatcher/src/test/resources/config/invalid-clients-missing-perimeter-versions.yaml
+++ b/hub/dispatcher/src/test/resources/config/invalid-clients-missing-perimeter-versions.yaml
@@ -1,0 +1,6 @@
+clients:
+  - client_id: fr.health.test.samu-v1
+    common_name: fr.health.test.samu-v1.fr
+    perimeters:
+      - name: '15-15'
+    editor: ANS

--- a/hub/dispatcher/src/test/resources/config/invalid-clients-no-perimeters.yaml
+++ b/hub/dispatcher/src/test/resources/config/invalid-clients-no-perimeters.yaml
@@ -1,0 +1,6 @@
+clients:
+  - client_id: fr.health.test.samu-v1
+    common_name: fr.health.test.samu-v1.fr
+    perimeters:
+      - name: '15-15'
+    editor: ANS

--- a/hub/dispatcher/src/test/resources/config/invalid-clients-no-perimeters.yaml
+++ b/hub/dispatcher/src/test/resources/config/invalid-clients-no-perimeters.yaml
@@ -1,6 +1,4 @@
 clients:
   - client_id: fr.health.test.samu-v1
     common_name: fr.health.test.samu-v1.fr
-    perimeters:
-      - name: '15-15'
     editor: ANS


### PR DESCRIPTION
## 🔎 Détails

Ajout d'un Bean `ClientPropertiesRegistry` pour accéder à la configuration client par client_id : 

- Ajout de Record PerimeterDefinition et ClientProperties
- A l'instantiation par Spring de la registry, chargement du fichier `clients.yaml` et construction d'une map de ClientProperties avec accesseur par client_id

Sur cette PR, le Bean est créé en plus de HubConfiguration et des autres maps. La bascule se fait dans la PR suivante.

- Surcharge dynamique de l'emplacement du fichier par défaut pour les tests


## 📸 Captures d'écran

| Avant | Après |
| ----- | ----- |
|       |       |

## 🔗Ticket associé

[1. [ Dispatcher ] créer un Bean de configuration à partir d'un fichier clients.yaml](https://app.asana.com/1/1201445755223134/project/1214554001624211/task/1215323679305300)