### PR TITLE
fix(lrm) : correction du chargement des exemples lors du filtrage par vHost

### DIFF
--- a/web/lrm/client/store/index.js
+++ b/web/lrm/client/store/index.js
@@ -238,6 +238,8 @@ export const useMainStore = defineStore('main', {
       });
     },
     loadMessageTypes(source) {
+      // Clear message types before fetching to prevent stale data from previous vhost
+      this._messageTypes = [];
       return fetch(source)
         .then((response) => response.json())
         .then((messageTypes) => {


### PR DESCRIPTION
## 🔎 Détails
Lors du changement de vHost sur le LRM Front, des erreurs 404 
apparaissaient lors du chargement des fichiers d'exemples JSON 
(ex: CU2_Geolocation_01.json).

<img width="959" height="271" alt="image" src="https://github.com/user-attachments/assets/9c125179-7cd4-455d-a0e2-94e99a2d4be2" />

Cause :
_messageTypes n'était pas vidé avant le fetch de la nouvelle liste. 
Pendant la transition (ex: 15-nexsis_v1.9 → 15-gps_v1.0), ExamplesList 
se déclenchait avec les anciens exemples de l'ancien vHost alors que 
la source pointait déjà vers la nouvelle version du modèle. Les deux 
versions du repo n'ayant pas le même messagesList.json (3.1.1 pour 
15-nexsis_v1.9, 1.0.0 pour 15-gps_v1.0), certains fichiers référencés 
dans l'ancienne liste n'existaient pas dans la nouvelle version :

<img width="838" height="292" alt="image" src="https://github.com/user-attachments/assets/1fcdb0ca-6378-4039-b028-771c5c529685" />
<img width="838" height="271" alt="image" src="https://github.com/user-attachments/assets/3d8d85b8-527e-42a0-a093-9dd4167afeb3" />

Fix : vider _messageTypes avant chaque fetch dans loadMessageTypes() 
pour garantir la cohérence entre les exemples chargés et la version 
du modèle associée au vHost sélectionné. Pendant la transition, 
ExamplesList reçoit une liste vide et ne tente aucun fetch. Une fois 
le fetch terminé, les nouveaux types sont cohérents avec la nouvelle 
source → plus de 404.

<img width="772" height="219" alt="image" src="https://github.com/user-attachments/assets/746333b6-bbcd-4422-b120-5f9bb9eada42" />




