### PR TITLE
[ Dispatcher] Refacto : migration des maps de configuration vers un objet de configuration client

### DIFF
--- a/hub/dispatcher/src/main/java/com/hubsante/hub/config/HubConfiguration.java
+++ b/hub/dispatcher/src/main/java/com/hubsante/hub/config/HubConfiguration.java
@@ -18,17 +18,12 @@ package com.hubsante.hub.config;
 import com.hubsante.hub.service.ClientPropertiesRegistry;
 import com.hubsante.model.EdxlHandler;
 import com.hubsante.model.Validator;
-import com.univocity.parsers.common.ParsingContext;
-import com.univocity.parsers.common.processor.ObjectRowProcessor;
-import com.univocity.parsers.csv.CsvParser;
-import com.univocity.parsers.csv.CsvParserSettings;
 import io.micrometer.core.aop.TimedAspect;
 import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.annotation.PostConstruct;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
-import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -40,14 +35,8 @@ import org.springframework.web.reactive.function.client.WebClient;
 @Configuration
 public class HubConfiguration {
 
-    private static final int ROW_LENGTH = 11;
     private static final String DATA_DIVIDER = ",";
     private static final String COLUMN_DIVIDER = ";";
-
-    private static final StructuredLogger structuredLog = new StructuredLogger(log);
-
-    @Value("${client.preferences.file}")
-    private File configFile;
 
     @Value("${supported.messages.file}")
     private File supportedMessagesFile;
@@ -62,104 +51,18 @@ public class HubConfiguration {
 
     @Autowired private ClientPropertiesRegistry clientPropertiesRegistry;
 
-    private Map<String, Map<String, String>> clientsPerimeterAndVersions = new HashMap<>();
     private List<String> supportedMessages;
 
     @PostConstruct
     public void init() throws Exception {
+        // We first get the parameterized default message TTL
+        defaultTTL = Long.parseLong(this.ttlProperty);
 
-        try {
-            // We first get the parameterized default message TTL
-            defaultTTL = Long.parseLong(this.ttlProperty);
+        // We explicitly set the Locale to ensure cross platform consistency
+        Locale.setDefault(Locale.ENGLISH);
 
-            // We explicitly set the Locale to ensure cross platform consistency
-            Locale.setDefault(Locale.ENGLISH);
-
-            // We define a custom row processor to read the config file
-            // we override the rowProcessed method on the fly to store the config in a HashMap
-            // then we define the parser settings and parse the file
-            ObjectRowProcessor clientPreferencesRowProcessor =
-                    new ObjectRowProcessor() {
-                        @Override
-                        public void rowProcessed(Object[] objects, ParsingContext parsingContext) {
-                            if (objects.length != ROW_LENGTH) {
-                                log.warn(
-                                        "There were more than {} columns in the client preferences file, extra columns are being ignored",
-                                        ROW_LENGTH);
-                            }
-                            String[] items = Arrays.asList(objects).toArray(new String[ROW_LENGTH]);
-                        }
-                    };
-            CsvParserSettings parserSettings = new CsvParserSettings();
-            parserSettings.getFormat().setLineSeparator("\n");
-            parserSettings.getFormat().setDelimiter(';');
-            parserSettings.setHeaderExtractionEnabled(true);
-            parserSettings.setNullValue("");
-            parserSettings.setProcessor(clientPreferencesRowProcessor);
-
-            CsvParser parser = new CsvParser(parserSettings);
-            parser.parse(new BufferedReader(new FileReader(configFile, StandardCharsets.UTF_8)));
-            clientsPerimeterAndVersions = loadClientsPerimetersAndVersions();
-            supportedMessages = loadSupportedMessages(vhost);
-        } catch (Exception e) {
-            throw new Exception("Could not read config file " + configFile.getAbsolutePath(), e);
-        }
+        supportedMessages = loadSupportedMessages(vhost);
     }
-
-    public Map<String, Map<String, String>> loadClientsPerimetersAndVersions() throws IOException {
-        Map<String, Map<String, String>> clientsPerimeterAndVersions = new HashMap<>();
-        BufferedReader reader =
-                new BufferedReader(new FileReader(configFile, StandardCharsets.UTF_8));
-        String headerLine = reader.readLine();
-        String[] headers = headerLine.split(COLUMN_DIVIDER);
-        int numberOfColumns = headers.length;
-
-        Set<String> perimeterNames =
-                Arrays.stream(Constants.Perimeter.values())
-                        .map(Constants.Perimeter::getName)
-                        .collect(Collectors.toSet());
-
-        Map<String, Integer> perimeterColumnIndexes = new HashMap<>();
-        for (int i = 0; i < numberOfColumns; i++) {
-            if (perimeterNames.contains(headers[i])) {
-                perimeterColumnIndexes.put(headers[i], i);
-            }
-        }
-        String line;
-        while ((line = reader.readLine()) != null) {
-            String[] values = line.split(COLUMN_DIVIDER, -1); // -1 allows trailing empty strings
-
-            if (values.length < numberOfColumns) continue;
-
-            String clientId = values[0];
-            Map<String, String> allPerimetersVersions = new HashMap<>();
-
-            for (Map.Entry<String, Integer> perimeterMatch : perimeterColumnIndexes.entrySet()) {
-                String perimeterName = perimeterMatch.getKey();
-                int columnIndex = perimeterMatch.getValue();
-                allPerimetersVersions.put(perimeterName, values[columnIndex]);
-            }
-
-            clientsPerimeterAndVersions.put(clientId, allPerimetersVersions);
-        }
-
-        reader.close();
-        return clientsPerimeterAndVersions;
-    }
-
-    //    public String[] getClientVersionsForPerimeter(String clientId, String perimeterName) {
-    //        Map<String, String> clientPerimeterDefinition =
-    //                clientsPerimeterAndVersions.getOrDefault(clientId, null);
-    //        if (clientPerimeterDefinition == null) {
-    //            structuredLog.warn(
-    //                    "ClientId was not found in clientsPerimeterAndVersions, or the variable is
-    // not initialized.",
-    //                    Map.of(LogConstants.RECIPIENT_ID, clientId));
-    //            return null;
-    //        }
-    //        String versions = clientPerimeterDefinition.getOrDefault(perimeterName, null);
-    //        return splitString(versions);
-    //    }
 
     public List<String> loadSupportedMessages(String vhost) throws Exception {
         List<String> supportedMessages = new ArrayList<>();

--- a/hub/dispatcher/src/main/java/com/hubsante/hub/config/HubConfiguration.java
+++ b/hub/dispatcher/src/main/java/com/hubsante/hub/config/HubConfiguration.java
@@ -15,6 +15,7 @@
  */
 package com.hubsante.hub.config;
 
+import com.hubsante.hub.service.ClientPropertiesRegistry;
 import com.hubsante.model.EdxlHandler;
 import com.hubsante.model.Validator;
 import com.univocity.parsers.common.ParsingContext;
@@ -26,13 +27,10 @@ import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.annotation.PostConstruct;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.util.*;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVParser;
-import org.apache.commons.csv.CSVRecord;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -45,8 +43,6 @@ public class HubConfiguration {
     private static final int ROW_LENGTH = 11;
     private static final String DATA_DIVIDER = ",";
     private static final String COLUMN_DIVIDER = ";";
-    private static final String CLIENT_ID_HEADER = "client_id";
-    private static final String INHIBITED_USE_CASES_HEADER = "inhibited_use_cases";
 
     private static final StructuredLogger structuredLog = new StructuredLogger(log);
 
@@ -64,11 +60,9 @@ public class HubConfiguration {
     @Value("${spring.rabbitmq.virtual-host}")
     private String vhost;
 
-    private HashMap<String, Boolean> useXmlPreferences = new HashMap<>();
-    private HashMap<String, Boolean> directCisuPreferences = new HashMap<>();
-    private HashMap<String, String> clientsEditorMap = new HashMap<>();
+    @Autowired private ClientPropertiesRegistry clientPropertiesRegistry;
+
     private Map<String, Map<String, String>> clientsPerimeterAndVersions = new HashMap<>();
-    private Map<String, List<String>> clientsInhibitedMessages = new HashMap<>();
     private List<String> supportedMessages;
 
     @PostConstruct
@@ -94,9 +88,6 @@ public class HubConfiguration {
                                         ROW_LENGTH);
                             }
                             String[] items = Arrays.asList(objects).toArray(new String[ROW_LENGTH]);
-                            useXmlPreferences.put(items[0], Boolean.parseBoolean(items[1]));
-                            directCisuPreferences.put(items[0], Boolean.parseBoolean(items[2]));
-                            clientsEditorMap.put(items[0], items[3]);
                         }
                     };
             CsvParserSettings parserSettings = new CsvParserSettings();
@@ -109,7 +100,6 @@ public class HubConfiguration {
             CsvParser parser = new CsvParser(parserSettings);
             parser.parse(new BufferedReader(new FileReader(configFile, StandardCharsets.UTF_8)));
             clientsPerimeterAndVersions = loadClientsPerimetersAndVersions();
-            clientsInhibitedMessages = loadClientsInhibitedMessages();
             supportedMessages = loadSupportedMessages(vhost);
         } catch (Exception e) {
             throw new Exception("Could not read config file " + configFile.getAbsolutePath(), e);
@@ -157,18 +147,19 @@ public class HubConfiguration {
         return clientsPerimeterAndVersions;
     }
 
-    public String[] getClientVersionsForPerimeter(String clientId, String perimeterName) {
-        Map<String, String> clientPerimeterDefinition =
-                clientsPerimeterAndVersions.getOrDefault(clientId, null);
-        if (clientPerimeterDefinition == null) {
-            structuredLog.warn(
-                    "ClientId was not found in clientsPerimeterAndVersions, or the variable is not initialized.",
-                    Map.of(LogConstants.RECIPIENT_ID, clientId));
-            return null;
-        }
-        String versions = clientPerimeterDefinition.getOrDefault(perimeterName, null);
-        return splitString(versions);
-    }
+    //    public String[] getClientVersionsForPerimeter(String clientId, String perimeterName) {
+    //        Map<String, String> clientPerimeterDefinition =
+    //                clientsPerimeterAndVersions.getOrDefault(clientId, null);
+    //        if (clientPerimeterDefinition == null) {
+    //            structuredLog.warn(
+    //                    "ClientId was not found in clientsPerimeterAndVersions, or the variable is
+    // not initialized.",
+    //                    Map.of(LogConstants.RECIPIENT_ID, clientId));
+    //            return null;
+    //        }
+    //        String versions = clientPerimeterDefinition.getOrDefault(perimeterName, null);
+    //        return splitString(versions);
+    //    }
 
     public List<String> loadSupportedMessages(String vhost) throws Exception {
         List<String> supportedMessages = new ArrayList<>();
@@ -198,62 +189,8 @@ public class HubConfiguration {
         return supportedMessages;
     }
 
-    private Map<String, List<String>> loadClientsInhibitedMessages() throws IOException {
-        Map<String, List<String>> result = new HashMap<>();
-
-        try (Reader reader = Files.newBufferedReader(configFile.toPath());
-                CSVParser parser =
-                        CSVFormat.DEFAULT
-                                .builder()
-                                .setDelimiter(';')
-                                .setHeader()
-                                .setSkipHeaderRecord(true)
-                                .setTrim(true)
-                                .build()
-                                .parse(reader)) {
-            boolean hasUseCasesColumn =
-                    parser.getHeaderMap().containsKey(INHIBITED_USE_CASES_HEADER);
-
-            for (CSVRecord record : parser) {
-
-                String clientId = record.get(CLIENT_ID_HEADER);
-                List<String> useCases;
-
-                if (hasUseCasesColumn) {
-                    useCases =
-                            Arrays.stream(record.get(INHIBITED_USE_CASES_HEADER).split(","))
-                                    .map(String::trim)
-                                    .filter(s -> !s.isEmpty())
-                                    .toList();
-                } else {
-                    useCases = List.of();
-                }
-
-                result.put(clientId, useCases);
-            }
-        }
-
-        return Collections.unmodifiableMap(result);
-    }
-
     public List<String> getSupportedMessages() {
         return supportedMessages;
-    }
-
-    public HashMap<String, Boolean> getUseXmlPreferences() {
-        return useXmlPreferences;
-    }
-
-    public HashMap<String, Boolean> getDirectCisuPreferences() {
-        return directCisuPreferences;
-    }
-
-    public HashMap<String, String> getClientsEditorMap() {
-        return clientsEditorMap;
-    }
-
-    public Map<String, List<String>> getClientsInhibitedMessages() {
-        return clientsInhibitedMessages;
     }
 
     public long getDefaultTTL() {
@@ -262,6 +199,10 @@ public class HubConfiguration {
 
     public String getVhost() {
         return vhost;
+    }
+
+    public ClientPropertiesRegistry getClientPropertiesRegistry() {
+        return clientPropertiesRegistry;
     }
 
     @Bean

--- a/hub/dispatcher/src/main/java/com/hubsante/hub/service/ClientPropertiesRegistry.java
+++ b/hub/dispatcher/src/main/java/com/hubsante/hub/service/ClientPropertiesRegistry.java
@@ -15,12 +15,15 @@
  */
 package com.hubsante.hub.service;
 
+import com.hubsante.hub.config.LogConstants;
+import com.hubsante.hub.config.StructuredLogger;
 import com.hubsante.hub.exception.ClientConfigurationException;
 import com.hubsante.hub.model.ClientProperties;
 import com.hubsante.hub.model.PerimeterDefinition;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
 import org.springframework.boot.context.properties.bind.Bindable;
@@ -31,7 +34,10 @@ import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
 
 @Component
+@Slf4j
 public class ClientPropertiesRegistry {
+    private static final StructuredLogger structuredLog = new StructuredLogger(log);
+
     private Map<String, ClientProperties> clientsById = Map.of();
 
     public ClientPropertiesRegistry(@Value("${client.configuration.file}") Resource resource)
@@ -135,12 +141,30 @@ public class ClientPropertiesRegistry {
     }
 
     public ClientProperties get(String clientId) {
-        ClientProperties clientProperties = clientsById.get(clientId);
+        return clientsById.get(clientId);
+    }
+
+    public String[] getClientVersionsForPerimeter(String clientId, String perimeterName) {
+        ClientProperties clientProperties = get(clientId);
 
         if (clientProperties == null) {
-            throw new ClientConfigurationException("client " + clientId + " is not configured");
+            structuredLog.warn(
+                    "Client has no configuration", Map.of(LogConstants.RECIPIENT_ID, clientId));
+            return null;
         }
 
-        return clientProperties;
+        PerimeterDefinition perimeter =
+                clientProperties.perimeters().stream()
+                        .filter(p -> p.name().equals(perimeterName))
+                        .findFirst()
+                        .orElse(null);
+
+        if (perimeter == null) {
+            structuredLog.warn(
+                    "Client does not support perimeter " + perimeterName,
+                    Map.of(LogConstants.RECIPIENT_ID, clientId));
+            return null;
+        }
+        return perimeter.versions().toArray(String[]::new);
     }
 }

--- a/hub/dispatcher/src/main/java/com/hubsante/hub/service/MessageHandler.java
+++ b/hub/dispatcher/src/main/java/com/hubsante/hub/service/MessageHandler.java
@@ -31,6 +31,7 @@ import com.hubsante.hub.config.HubConfiguration;
 import com.hubsante.hub.config.LogConstants;
 import com.hubsante.hub.config.StructuredLogger;
 import com.hubsante.hub.exception.*;
+import com.hubsante.hub.model.ClientProperties;
 import com.hubsante.hub.utils.ConversionRulesCommand;
 import com.hubsante.hub.utils.ConversionUtils;
 import com.hubsante.hub.utils.EdxlUtils;
@@ -47,10 +48,7 @@ import com.hubsante.model.report.ErrorWrapper;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.AmqpRejectAndDontRequeueException;
 import org.springframework.amqp.core.Message;
@@ -89,6 +87,7 @@ public class MessageHandler {
             MeterRegistry registry,
             XmlMapper xmlMapper,
             ObjectMapper jsonMapper,
+            ClientPropertiesRegistry clientPropertiesRegistry,
             ConversionHandler conversionHandler) {
         this.rabbitTemplate = rabbitTemplate;
         this.edxlHandler = edxlHandler;
@@ -200,7 +199,11 @@ public class MessageHandler {
             String routingKey = infoQueueName;
 
             Message errorAmqpMessage;
-            if (convertToXML(sender, hubConfig.getUseXmlPreferences().get(sender))) {
+            Boolean useXML =
+                    hubConfig.getClientPropertiesRegistry().get(sender) != null
+                            ? hubConfig.getClientPropertiesRegistry().get(sender).useXml()
+                            : null;
+            if (convertToXML(sender, useXML)) {
                 errorAmqpMessage =
                         new Message(
                                 edxlHandler.serializeXmlEDXL(errorEdxlMessage).getBytes(),
@@ -498,7 +501,11 @@ public class MessageHandler {
         String messageType = getUseCaseFromMessage(edxlMessage.getFirstContentMessage());
 
         try {
-            if (convertToXML(recipientId, hubConfig.getUseXmlPreferences().get(recipientId))) {
+            Boolean useXML =
+                    hubConfig.getClientPropertiesRegistry().get(recipientId) != null
+                            ? hubConfig.getClientPropertiesRegistry().get(recipientId).useXml()
+                            : null;
+            if (convertToXML(recipientId, useXML)) {
                 edxlString = edxlHandler.serializeXmlEDXL(edxlMessage);
                 fwdAmqpProperties.setContentType(MessageProperties.CONTENT_TYPE_XML);
             } else {
@@ -590,11 +597,17 @@ public class MessageHandler {
     }
 
     protected void inhibitMessageIfNeeded(EdxlMessage edxlMessage) {
+        String recipientId = getRecipientID(edxlMessage);
+        String useCase = EdxlUtils.getUseCaseFromMessage(edxlMessage.getFirstContentMessage());
+        ClientProperties clientProperties =
+                hubConfig.getClientPropertiesRegistry().get(recipientId);
+        List<String> inhibitedUseCases = new ArrayList<>();
+
+        if (clientProperties != null) {
+            inhibitedUseCases = clientProperties.inhibitedUseCases();
+        }
         checkMessageNotInhibited(
-                getRecipientID(edxlMessage),
-                EdxlUtils.getUseCaseFromMessage(edxlMessage.getFirstContentMessage()),
-                hubConfig.getClientsInhibitedMessages(),
-                edxlMessage.getDistributionID());
+                recipientId, useCase, inhibitedUseCases, edxlMessage.getDistributionID());
     }
 
     private void logMessage(Message message, EdxlMessage edxlMessage, String receivedEdxl) {
@@ -685,6 +698,7 @@ public class MessageHandler {
     }
 
     private String getEditorFromSender(String sender) {
-        return hubConfig.getClientsEditorMap().getOrDefault(sender, UNKNOWN);
+        ClientProperties clientProperties = hubConfig.getClientPropertiesRegistry().get(sender);
+        return clientProperties != null ? clientProperties.editor() : UNKNOWN;
     }
 }

--- a/hub/dispatcher/src/main/java/com/hubsante/hub/utils/ConversionUtils.java
+++ b/hub/dispatcher/src/main/java/com/hubsante/hub/utils/ConversionUtils.java
@@ -20,6 +20,7 @@ import static com.hubsante.hub.config.Constants.*;
 import static com.hubsante.hub.utils.MessageUtils.*;
 
 import com.hubsante.hub.config.HubConfiguration;
+import com.hubsante.hub.model.ClientProperties;
 import com.hubsante.model.edxl.EdxlMessage;
 import java.util.Arrays;
 import lombok.extern.slf4j.Slf4j;
@@ -83,8 +84,10 @@ public class ConversionUtils {
                 (isCisuSender && !isDirectCisu) ? Perimeter.HEALTH.getName() : sourcePerimeter;
 
         targetVersionsOnTargetPerimeter =
-                hubConfig.getClientVersionsForPerimeter(
-                        recipientId, targetPerimeter); // ex ['1.5, 2.0']
+                hubConfig
+                        .getClientPropertiesRegistry()
+                        .getClientVersionsForPerimeter(
+                                recipientId, targetPerimeter); // ex ['1.5, 2.0']
         return formatVersionToVhosts(
                 targetVersionsOnTargetPerimeter,
                 targetPerimeter); // ex ["15-15_v1.5", "15-15_v2.0"]
@@ -135,10 +138,14 @@ public class ConversionUtils {
         String recipientId = getRecipientID(edxlMessage);
         String senderId = edxlMessage.getSenderID();
         String healthActor = senderId.startsWith(HEALTH_PREFIX) ? senderId : recipientId;
-        Boolean directCisuPreference =
-                hubConfig
-                        .getDirectCisuPreferences()
-                        .getOrDefault(healthActor, DEFAULT_DIRECT_CISU_PREFERENCE);
-        return directCisuPreference != null && directCisuPreference;
+
+        ClientProperties healthActorProperties =
+                hubConfig.getClientPropertiesRegistry().get(healthActor);
+        boolean directCisuPreference =
+                healthActorProperties != null
+                        ? healthActorProperties.directCisu()
+                        : DEFAULT_DIRECT_CISU_PREFERENCE;
+
+        return directCisuPreference;
     }
 }

--- a/hub/dispatcher/src/main/java/com/hubsante/hub/utils/MessageUtils.java
+++ b/hub/dispatcher/src/main/java/com/hubsante/hub/utils/MessageUtils.java
@@ -155,13 +155,10 @@ public class MessageUtils {
     public static void checkMessageNotInhibited(
             String recipientId,
             String useCase,
-            Map<String, List<String>> inhibitedMessagesByClient,
+            List<String> inhibitedUseCases,
             String distributionId) {
 
-        List<String> blockedUseCases =
-                inhibitedMessagesByClient.getOrDefault(recipientId, List.of());
-
-        boolean isInhibited = blockedUseCases.contains(useCase);
+        boolean isInhibited = inhibitedUseCases.contains(useCase);
 
         if (isInhibited) {
             String errorMessage =

--- a/hub/dispatcher/src/main/resources/application-XXX.template.yaml
+++ b/hub/dispatcher/src/main/resources/application-XXX.template.yaml
@@ -9,8 +9,8 @@ spring:
   main:
     web-application-type: reactive
 client:
-  preferences:
-    file: "file:<PATH_TO_LOCAL_DEV_DIRECTORY>/config/values/client.preferences.csv"
+  configuration:
+    file: "file:<PATH_TO_LOCAL_DEV_DIRECTORY>/config/values/clients.yaml"
 supported:
   messages:
     file: "file:<PATH_TO_LOCAL_DEV_DIRECTORY>/dispatcher/supported.messages.csv"

--- a/hub/dispatcher/src/main/resources/application.properties
+++ b/hub/dispatcher/src/main/resources/application.properties
@@ -19,7 +19,6 @@ spring.rabbitmq.template.mandatory=true
 app.version=${APP_VERSION:unknown}
 app.model-version=${APP_MODEL_VERSION:unknown}
 
-client.preferences.file=file:/config/client.preferences.csv
 supported.messages.file=file:/config/supported.messages.csv
 client.configuration.file=file:/config/clients.yaml
 # dispatcher.default.ttl needs to be syncd with RabbitMQ conf :

--- a/hub/dispatcher/src/test/java/com/hubsante/hub/service/ClientPropertiesRegistryTest.java
+++ b/hub/dispatcher/src/test/java/com/hubsante/hub/service/ClientPropertiesRegistryTest.java
@@ -65,8 +65,8 @@ public class ClientPropertiesRegistryTest {
     public void shouldLoadClientConfiguration() {
         assertNotNull(this.clientPropertiesRegistry);
 
-        ClientProperties samuV1Properties = clientPropertiesRegistry.get("fr.health.test.samu-v1");
-        ClientProperties samuV3Properties = clientPropertiesRegistry.get("fr.health.test.samu-v3");
+        ClientProperties samuV1Properties = clientPropertiesRegistry.get("fr.health.samuV1");
+        ClientProperties samuV3Properties = clientPropertiesRegistry.get("fr.health.samuV3");
 
         assertThrows(
                 ClientConfigurationException.class, () -> clientPropertiesRegistry.get("unknown"));

--- a/hub/dispatcher/src/test/java/com/hubsante/hub/service/ClientPropertiesRegistryTest.java
+++ b/hub/dispatcher/src/test/java/com/hubsante/hub/service/ClientPropertiesRegistryTest.java
@@ -66,14 +66,12 @@ public class ClientPropertiesRegistryTest {
         assertNotNull(this.clientPropertiesRegistry);
 
         ClientProperties samuV1Properties = clientPropertiesRegistry.get("fr.health.samuV1");
-        ClientProperties samuV3Properties = clientPropertiesRegistry.get("fr.health.samuV3");
-
-        assertThrows(
-                ClientConfigurationException.class, () -> clientPropertiesRegistry.get("unknown"));
-
         List<String> samuV1InhibitedMessages = samuV1Properties.inhibitedUseCases();
+
         assertNotNull(samuV1InhibitedMessages);
         assertEquals(List.of("ResourcesInfoCisuWrapper"), samuV1InhibitedMessages);
+
+        assertNull(clientPropertiesRegistry.get("unknown"));
     }
 
     @Test

--- a/hub/dispatcher/src/test/java/com/hubsante/hub/service/ClientPropertiesRegistryTest.java
+++ b/hub/dispatcher/src/test/java/com/hubsante/hub/service/ClientPropertiesRegistryTest.java
@@ -49,11 +49,6 @@ public class ClientPropertiesRegistryTest {
                         Objects.requireNonNull(
                                 classLoader.getResource("config/supported.messages.csv")));
         propertiesRegistry.add(
-                "client.preferences.file",
-                () ->
-                        Objects.requireNonNull(
-                                classLoader.getResource("config/client.preferences.csv")));
-        propertiesRegistry.add(
                 "client.configuration.file",
                 () -> Objects.requireNonNull(classLoader.getResource("config/clients.yaml")));
         propertiesRegistry.add("hubsante.default.message.ttl", () -> 5);

--- a/hub/dispatcher/src/test/java/com/hubsante/hub/service/ConversionUtilsTest.java
+++ b/hub/dispatcher/src/test/java/com/hubsante/hub/service/ConversionUtilsTest.java
@@ -18,18 +18,15 @@ package com.hubsante.hub.service;
 import static com.hubsante.hub.utils.ConversionUtils.isAlreadyCisuConverted;
 import static com.hubsante.hub.utils.ConversionUtils.trimVersionSuffix;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 import com.hubsante.hub.config.HubConfiguration;
 import com.hubsante.hub.utils.ConversionUtils;
 import com.hubsante.hub.utils.MessageUtils;
-import com.hubsante.model.cisu.CreateCaseWrapper;
 import com.hubsante.model.edxl.EdxlMessage;
-import com.hubsante.model.emsi.EmsiWrapper;
-import com.hubsante.model.health.CreateCaseHealthWrapper;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -48,24 +45,17 @@ public class ConversionUtilsTest {
     private HubConfiguration hubConfig;
 
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private ClientPropertiesRegistry clientPropertiesRegistry;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private EdxlMessage edxlMessage;
-
-    @Mock private CreateCaseWrapper createCaseWrapper;
-
-    @Mock private CreateCaseHealthWrapper createCaseHealthWrapper;
-
-    @Mock private EmsiWrapper emsiWrapper;
-
-    private HashMap<String, Boolean> directCisuPreferences;
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
 
-        directCisuPreferences = new HashMap<>();
-        directCisuPreferences.put("fr.health.samuDirectCisu", true);
-
-        when(hubConfig.getDirectCisuPreferences()).thenReturn(directCisuPreferences);
+        when(hubConfig.getClientPropertiesRegistry()).thenReturn(clientPropertiesRegistry);
+        when(clientPropertiesRegistry.get(anyString()).directCisu()).thenReturn(false);
     }
 
     @Test
@@ -125,7 +115,7 @@ public class ConversionUtilsTest {
             mockedMessageUtils
                     .when(() -> MessageUtils.getRecipientID(edxlMessage))
                     .thenReturn(recipientId);
-            when(hubConfig.getClientVersionsForPerimeter(recipientId, perimeter))
+            when(clientPropertiesRegistry.getClientVersionsForPerimeter(recipientId, perimeter))
                     .thenReturn(versions);
 
             assertEquals(
@@ -239,8 +229,9 @@ public class ConversionUtilsTest {
 
             when(edxlMessage.getSenderID()).thenReturn("fr.health.samuVX");
 
-            when(hubConfig.getClientVersionsForPerimeter("fr.health.samuA", "15-15"))
+            when(clientPropertiesRegistry.getClientVersionsForPerimeter("fr.health.samuA", "15-15"))
                     .thenReturn(new String[] {"1.5", "2.0", "2.1"});
+
             mockedMessageUtils
                     .when(() -> MessageUtils.getRecipientID(edxlMessage))
                     .thenReturn("fr.health.samuA");
@@ -248,7 +239,8 @@ public class ConversionUtilsTest {
                     new String[] {"15-15_v1.5", "15-15_v2.0", "15-15_v2.1"},
                     ConversionUtils.getTargetVHosts(hubConfig, edxlMessage));
 
-            when(hubConfig.getClientVersionsForPerimeter("fr.health.samuV1", "15-15"))
+            when(clientPropertiesRegistry.getClientVersionsForPerimeter(
+                            "fr.health.samuV1", "15-15"))
                     .thenReturn(new String[] {"1.5"});
             mockedMessageUtils
                     .when(() -> MessageUtils.getRecipientID(edxlMessage))
@@ -257,14 +249,16 @@ public class ConversionUtilsTest {
                     new String[] {"15-15_v1.5"},
                     ConversionUtils.getTargetVHosts(hubConfig, edxlMessage));
 
-            when(hubConfig.getClientVersionsForPerimeter("fr.health.samuNull", "15-15"))
+            when(clientPropertiesRegistry.getClientVersionsForPerimeter(
+                            "fr.health.samuNull", "15-15"))
                     .thenReturn(null);
             mockedMessageUtils
                     .when(() -> MessageUtils.getRecipientID(edxlMessage))
                     .thenReturn("fr.health.samuNull");
             assertArrayEquals(null, ConversionUtils.getTargetVHosts(hubConfig, edxlMessage));
 
-            when(hubConfig.getClientVersionsForPerimeter("fr.health.samuEmpty", "15-15"))
+            when(clientPropertiesRegistry.getClientVersionsForPerimeter(
+                            "fr.health.samuEmpty", "15-15"))
                     .thenReturn(new String[] {});
             mockedMessageUtils
                     .when(() -> MessageUtils.getRecipientID(edxlMessage))
@@ -279,7 +273,8 @@ public class ConversionUtilsTest {
             mockedMessageUtils
                     .when(() -> MessageUtils.getRecipientID(edxlMessage))
                     .thenReturn("fr.health.samuV1");
-            when(hubConfig.getClientVersionsForPerimeter("fr.health.samuV1", "15-15"))
+            when(clientPropertiesRegistry.getClientVersionsForPerimeter(
+                            "fr.health.samuV1", "15-15"))
                     .thenReturn(new String[] {"1.5"});
             assertArrayEquals(
                     new String[] {"15-15_v1.5"},
@@ -308,6 +303,8 @@ public class ConversionUtilsTest {
 
             // Direct Cisu cases
             when(hubConfig.getVhost()).thenReturn("15-nexsis_v1.9");
+            when(clientPropertiesRegistry.get("fr.health.samuDirectCisu").directCisu())
+                    .thenReturn(true);
             when(edxlMessage.getSenderID()).thenReturn("fr.health.samuDirectCisu");
             mockedMessageUtils
                     .when(() -> MessageUtils.getRecipientID(edxlMessage))
@@ -317,7 +314,8 @@ public class ConversionUtilsTest {
                     ConversionUtils.getTargetVHosts(hubConfig, edxlMessage));
 
             when(edxlMessage.getSenderID()).thenReturn("fr.fire.test");
-            when(hubConfig.getClientVersionsForPerimeter("fr.health.samuDirectCisu", "15-nexsis"))
+            when(clientPropertiesRegistry.getClientVersionsForPerimeter(
+                            "fr.health.samuDirectCisu", "15-nexsis"))
                     .thenReturn(new String[] {"1.9"});
             mockedMessageUtils
                     .when(() -> MessageUtils.getRecipientID(edxlMessage))
@@ -362,11 +360,11 @@ public class ConversionUtilsTest {
                     .thenReturn("fr.fire.sdisZ");
 
             // Health actor in direct CISU preferences - true
-            directCisuPreferences.put("fr.health.samuA", true);
+            when(clientPropertiesRegistry.get("fr.health.samuA").directCisu()).thenReturn(true);
             assertTrue(ConversionUtils.isDirectCisuForHealthActor(hubConfig, edxlMessage));
 
             // Health actor in direct CISU preferences - false
-            directCisuPreferences.put("fr.health.samuA", false);
+            when(clientPropertiesRegistry.get("fr.health.samuA").directCisu()).thenReturn(false);
             assertFalse(ConversionUtils.isDirectCisuForHealthActor(hubConfig, edxlMessage));
 
             // Health actor not in direct CISU preferences

--- a/hub/dispatcher/src/test/java/com/hubsante/hub/service/DispatcherTest.java
+++ b/hub/dispatcher/src/test/java/com/hubsante/hub/service/DispatcherTest.java
@@ -120,11 +120,6 @@ public class DispatcherTest {
                         Objects.requireNonNull(
                                 classLoader.getResource("config/supported.messages.csv")));
         propertiesRegistry.add(
-                "client.preferences.file",
-                () ->
-                        Objects.requireNonNull(
-                                classLoader.getResource("config/client.preferences.csv")));
-        propertiesRegistry.add(
                 "client.configuration.file",
                 () -> Objects.requireNonNull(classLoader.getResource("config/clients.yaml")));
         propertiesRegistry.add("hubsante.default.message.ttl", () -> 5);

--- a/hub/dispatcher/src/test/java/com/hubsante/hub/service/DispatcherTest.java
+++ b/hub/dispatcher/src/test/java/com/hubsante/hub/service/DispatcherTest.java
@@ -86,6 +86,7 @@ public class DispatcherTest {
 
     @Autowired private EdxlHandler edxlHandler;
     @Autowired private HubConfiguration hubConfig;
+    @Autowired private ClientPropertiesRegistry clientPropertiesRegistry;
     @Autowired private Validator validator;
     private MessageHandler messageHandler;
     private ConversionHandler conversionHandler;
@@ -97,16 +98,13 @@ public class DispatcherTest {
     private final String SAMU_B_ROUTING_KEY = "fr.health.samuB";
     private final String SAMU_B_MESSAGE_QUEUE = SAMU_B_ROUTING_KEY + ".message";
     private final String SAMU_B_INFO_QUEUE = SAMU_B_ROUTING_KEY + ".info";
-    private final String SAMU_B_ERROR_QUEUE = SAMU_B_ROUTING_KEY + ".error";
     private final String SAMU_A_ROUTING_KEY = "fr.health.samuA";
     private final String SAMU_A_MESSAGE_QUEUE = SAMU_A_ROUTING_KEY + ".message";
     private final String SAMU_A_INFO_QUEUE = SAMU_A_ROUTING_KEY + ".info";
-    private final String SAMU_A_ERROR_QUEUE = SAMU_A_ROUTING_KEY + ".error";
     private final String SAMU_A_DISTRIBUTION_ID =
             "fr.health.samuA_2608323d-507d-4cbf-bf74-52007f8124ea";
     private final String SDIS_C_ROUTING_KEY = "fr.fire.sdisC";
 
-    private final String TEST_VHOST = "default-vhost";
     private final String TEST_EDITOR = "default-editor";
     private final String INCONSISTENT_ROUTING_KEY = "fr.health.no-samu";
     private final String JSON = MessageProperties.CONTENT_TYPE_JSON;
@@ -144,6 +142,7 @@ public class DispatcherTest {
                         registry,
                         xmlMapper,
                         jsonMapper,
+                        clientPropertiesRegistry,
                         conversionHandler);
         conversionHandler = Mockito.spy(new ConversionHandler(conversionWebClient, edxlHandler));
         dispatcher =
@@ -1100,12 +1099,12 @@ public class DispatcherTest {
     @DisplayName("should transfer to another vhost when an error is raised after message transfer")
     public void transferErrorToOtherVhost() throws IOException, ValidationException {
         HubConfiguration hubConfigSpy = Mockito.spy(hubConfig);
+        ClientPropertiesRegistry clientPropertiesRegistrySpy =
+                Mockito.spy(clientPropertiesRegistry);
+        doReturn(clientPropertiesRegistrySpy).when(hubConfigSpy).getClientPropertiesRegistry();
         doReturn("15-15_v2.0").when(hubConfigSpy).getVhost();
-        doReturn(new HashMap<>(Map.of(SAMU_A_ROUTING_KEY, false)))
-                .when(hubConfigSpy)
-                .getUseXmlPreferences();
         doReturn(new String[] {"1.5"})
-                .when(hubConfigSpy)
+                .when(clientPropertiesRegistrySpy)
                 .getClientVersionsForPerimeter(SAMU_A_ROUTING_KEY, "15-15");
 
         Validator validatorMock = Mockito.mock(Validator.class);
@@ -1124,6 +1123,7 @@ public class DispatcherTest {
                         registry,
                         xmlMapper,
                         jsonMapper,
+                        clientPropertiesRegistrySpy,
                         conversionHandler);
         Dispatcher dispatcherSpy =
                 new Dispatcher(
@@ -1164,12 +1164,12 @@ public class DispatcherTest {
     @DisplayName("should forward error message directly when error is received after conversion")
     public void sendErrorMessageToSameVhost() throws IOException {
         HubConfiguration hubConfigSpy = Mockito.spy(hubConfig);
+        ClientPropertiesRegistry clientPropertiesRegistrySpy =
+                Mockito.spy(clientPropertiesRegistry);
+        doReturn(clientPropertiesRegistrySpy).when(hubConfigSpy).getClientPropertiesRegistry();
         doReturn("15-15_v1.5").when(hubConfigSpy).getVhost();
-        doReturn(new HashMap<>(Map.of(SAMU_A_ROUTING_KEY, false)))
-                .when(hubConfigSpy)
-                .getUseXmlPreferences();
         doReturn(new String[] {"1.5"})
-                .when(hubConfigSpy)
+                .when(clientPropertiesRegistrySpy)
                 .getClientVersionsForPerimeter(SAMU_A_ROUTING_KEY, "15-15");
 
         MessageHandler messageHandlerSpy =
@@ -1181,6 +1181,7 @@ public class DispatcherTest {
                         registry,
                         xmlMapper,
                         jsonMapper,
+                        clientPropertiesRegistrySpy,
                         conversionHandler);
         Dispatcher dispatcherSpy =
                 new Dispatcher(
@@ -1206,12 +1207,12 @@ public class DispatcherTest {
     @DisplayName("should send error message to sender info queue when error is raised")
     public void sendErrorMessageWhenErrorIsRaised() throws IOException, ValidationException {
         HubConfiguration hubConfigSpy = Mockito.spy(hubConfig);
+        ClientPropertiesRegistry clientPropertiesRegistrySpy =
+                Mockito.spy(clientPropertiesRegistry);
+        doReturn(clientPropertiesRegistrySpy).when(hubConfigSpy).getClientPropertiesRegistry();
         doReturn("15-15_v1.5").when(hubConfigSpy).getVhost();
-        doReturn(new HashMap<>(Map.of(SAMU_A_ROUTING_KEY, false)))
-                .when(hubConfigSpy)
-                .getUseXmlPreferences();
         doReturn(new String[] {"1.5"})
-                .when(hubConfigSpy)
+                .when(clientPropertiesRegistrySpy)
                 .getClientVersionsForPerimeter(SAMU_A_ROUTING_KEY, "15-15");
 
         Validator validatorMock = Mockito.mock(Validator.class);
@@ -1230,6 +1231,7 @@ public class DispatcherTest {
                         registry,
                         xmlMapper,
                         jsonMapper,
+                        clientPropertiesRegistrySpy,
                         conversionHandler);
         Dispatcher dispatcherSpy =
                 new Dispatcher(

--- a/hub/dispatcher/src/test/java/com/hubsante/hub/service/HubApplicationTests.java
+++ b/hub/dispatcher/src/test/java/com/hubsante/hub/service/HubApplicationTests.java
@@ -53,10 +53,6 @@ class HubApplicationTests {
                                     + Thread.currentThread()
                                             .getContextClassLoader()
                                             .getResource("config/certs/trustStore"),
-                            "client.preferences.file="
-                                    + Thread.currentThread()
-                                            .getContextClassLoader()
-                                            .getResource("config/client.preferences.csv"),
                             "client.configuration.file="
                                     + Thread.currentThread()
                                             .getContextClassLoader()

--- a/hub/dispatcher/src/test/java/com/hubsante/hub/service/HubConfigurationTest.java
+++ b/hub/dispatcher/src/test/java/com/hubsante/hub/service/HubConfigurationTest.java
@@ -21,9 +21,7 @@ import com.hubsante.hub.config.HubConfiguration;
 import java.io.File;
 import java.io.FileWriter;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,18 +43,6 @@ public class HubConfigurationTest {
         }
 
         ReflectionTestUtils.setField(hubConfig, "supportedMessagesFile", tempFile);
-
-        File tempConfigFile = File.createTempFile("client.preferences", ".csv");
-        try (FileWriter writer = new FileWriter(tempConfigFile, StandardCharsets.UTF_8)) {
-            writer.write(
-                    "client_id;useXML;directCISU;editor;lrm_test;15-15;15-nexsis;15-smur;15-gps\n");
-            writer.write(
-                    "fr.health.samuA;false;false;default-editor;false;1.5,2.0,2.1;1.9;1.7;2.0\n");
-            writer.write("fr.health.samuV2;false;false;default-editor;false;2.0;1.9;1.7;2.0\n");
-            writer.write("fr.health.samuV1;false;false;default-editor;false;1.5;;;\n");
-        }
-
-        ReflectionTestUtils.setField(hubConfig, "configFile", tempConfigFile);
     }
 
     @Test
@@ -110,36 +96,5 @@ public class HubConfigurationTest {
         Assertions.assertEquals(2, supportedMessages.size());
         Assertions.assertTrue(supportedMessages.contains("ReferenceWrapper"));
         Assertions.assertTrue(supportedMessages.contains("ErrorWrapper"));
-    }
-
-    @Test
-    void testLoadPerimeterVersions() throws Exception {
-        Map<String, Map<String, String>> clientsPerimetersAndVersions =
-                hubConfig.loadClientsPerimetersAndVersions();
-        Map<String, Map<String, String>> expectedMap = new HashMap<>();
-
-        Map<String, String> samuV1Map = new HashMap<>();
-        samuV1Map.put("15-smur", "");
-        samuV1Map.put("15-15", "1.5");
-        samuV1Map.put("15-nexsis", "");
-        samuV1Map.put("15-gps", "");
-        expectedMap.put("fr.health.samuV1", samuV1Map);
-
-        Map<String, String> samuV2Map = new HashMap<>();
-        samuV2Map.put("15-smur", "1.7");
-        samuV2Map.put("15-15", "2.0");
-        samuV2Map.put("15-nexsis", "1.9");
-        samuV2Map.put("15-gps", "2.0");
-        expectedMap.put("fr.health.samuV2", samuV2Map);
-
-        Map<String, String> samuAMap = new HashMap<>();
-        samuAMap.put("15-smur", "1.7");
-        samuAMap.put("15-15", "1.5,2.0,2.1");
-        samuAMap.put("15-nexsis", "1.9");
-        samuAMap.put("15-gps", "2.0");
-        expectedMap.put("fr.health.samuA", samuAMap);
-        System.out.println(clientsPerimetersAndVersions);
-
-        Assertions.assertEquals(expectedMap, clientsPerimetersAndVersions);
     }
 }

--- a/hub/dispatcher/src/test/java/com/hubsante/hub/service/LogIntegrityTest.java
+++ b/hub/dispatcher/src/test/java/com/hubsante/hub/service/LogIntegrityTest.java
@@ -61,6 +61,7 @@ public class LogIntegrityTest {
     @Autowired private EdxlHandler edxlHandler;
     @Autowired private Validator validator;
     @Autowired private HubConfiguration hubConfiguration;
+    @Autowired private ClientPropertiesRegistry clientPropertiesRegistry;
     @Autowired private MeterRegistry meterRegistry;
     @Autowired private XmlMapper xmlMapper;
     @Autowired private ObjectMapper jsonMapper;
@@ -157,6 +158,7 @@ public class LogIntegrityTest {
                         meterRegistry,
                         xmlMapper,
                         jsonMapper,
+                        clientPropertiesRegistry,
                         conversionHandler);
 
         dispatcher =

--- a/hub/dispatcher/src/test/java/com/hubsante/hub/service/LogIntegrityTest.java
+++ b/hub/dispatcher/src/test/java/com/hubsante/hub/service/LogIntegrityTest.java
@@ -83,11 +83,6 @@ public class LogIntegrityTest {
                         Objects.requireNonNull(
                                 classLoader.getResource("config/supported.messages.csv")));
         propertiesRegistry.add(
-                "client.preferences.file",
-                () ->
-                        Objects.requireNonNull(
-                                classLoader.getResource("config/client.preferences.csv")));
-        propertiesRegistry.add(
                 "client.configuration.file",
                 () -> Objects.requireNonNull(classLoader.getResource("config/clients.yaml")));
         propertiesRegistry.add("dispatcher.default.ttl", () -> 600);

--- a/hub/dispatcher/src/test/java/com/hubsante/hub/service/RabbitIntegrationAbstract.java
+++ b/hub/dispatcher/src/test/java/com/hubsante/hub/service/RabbitIntegrationAbstract.java
@@ -135,10 +135,6 @@ public class RabbitIntegrationAbstract {
                                     + Thread.currentThread()
                                             .getContextClassLoader()
                                             .getResource("config/certs/trustStore"),
-                            "client.preferences.file="
-                                    + Thread.currentThread()
-                                            .getContextClassLoader()
-                                            .getResource("config/client.preferences.csv"),
                             "client.configuration.file="
                                     + Thread.currentThread()
                                             .getContextClassLoader()

--- a/hub/dispatcher/src/test/java/com/hubsante/hub/utils/MessageUtilsTest.java
+++ b/hub/dispatcher/src/test/java/com/hubsante/hub/utils/MessageUtilsTest.java
@@ -47,7 +47,7 @@ public class MessageUtilsTest {
                                 checkMessageNotInhibited(
                                         LIMITED_CLIENT,
                                         INHIBITED_MESSAGE,
-                                        inhibitedMessagesByClient,
+                                        inhibitedMessagesByClient.get(LIMITED_CLIENT),
                                         DISTRIBUTION_ID));
 
         assertEquals(
@@ -63,7 +63,7 @@ public class MessageUtilsTest {
                         checkMessageNotInhibited(
                                 LIMITED_CLIENT,
                                 UNRESTRICTED_MESSAGE,
-                                inhibitedMessagesByClient,
+                                inhibitedMessagesByClient.get(LIMITED_CLIENT),
                                 DISTRIBUTION_ID));
     }
 
@@ -75,7 +75,7 @@ public class MessageUtilsTest {
                         checkMessageNotInhibited(
                                 UNRESTRICTED_CLIENT,
                                 INHIBITED_MESSAGE,
-                                inhibitedMessagesByClient,
+                                inhibitedMessagesByClient.get(UNRESTRICTED_CLIENT),
                                 DISTRIBUTION_ID));
     }
 }

--- a/hub/dispatcher/src/test/resources/config/client.preferences.csv
+++ b/hub/dispatcher/src/test/resources/config/client.preferences.csv
@@ -1,6 +1,0 @@
-client_id;useXML;directCISU;editor;lrm_test;15-15;15-nexsis;15-smur;15-gps
-fr.health.samuA;false;false;default-editor;false;1.5,2.0,2.1;1.9;1.7;2.0
-fr.health.samuB;true;true;default-editor;false;1.5,2.0,2.1;1.9;1.7;2.0
-fr.health.samuV1;false;false;default-editor;false;1.5;1.9;1.7;2.0
-fr.health.samuV2;false;false;default-editor;false;2.0;1.9;1.7;2.0
-fr.health.samuV3;false;false;default-editor;false;2.1;1.9;1.7;2.0

--- a/hub/dispatcher/src/test/resources/config/clients.yaml
+++ b/hub/dispatcher/src/test/resources/config/clients.yaml
@@ -1,35 +1,163 @@
 clients:
-  - client_id: fr.health.test.samu-v1
-    common_name: fr.health.test.samu-v1.fr
+  - client_id: fr.health.samuA
+    common_name: fr.health.samuA
     perimeters:
       - name: '15-15'
         versions:
           - '1.5'
-    editor: ANS
+          - '2.0'
+          - '2.1'
+      - name: '15-smur'
+        versions:
+          - '1.7'
+      - name: '15-nexsis'
+        versions:
+          - '1.9'
+      - name: '15-gps'
+        versions:
+          - '2.0'
+      - name: '15-sas'
+        versions:
+          - '1.0'
+    editor: default-editor
+    lrmPerimeterVersions:
+      - '1.5'
+      - '2.0'
+      - '2.1'
+    cisuPerimeterVersions:
+      - '1.9'
+    smurPerimeterVersions:
+      - '1.7'
+    gpsPerimeterVersions:
+      - '2.0'
+    sasPerimeterVersions:
+      - '1.0'
+    lrm_test: false
+  - client_id: fr.health.samuB
+    common_name: fr.health.samuB
+    perimeters:
+      - name: '15-15'
+        versions:
+          - '1.5'
+          - '2.0'
+          - '2.1'
+      - name: '15-smur'
+        versions:
+          - '1.7'
+      - name: '15-nexsis'
+        versions:
+          - '1.9'
+      - name: '15-gps'
+        versions:
+          - '2.0'
+      - name: '15-sas'
+        versions:
+          - '1.0'
+    useXML: true
+    directCISU: true
+    editor: default-editor
+    lrmPerimeterVersions:
+      - '1.5'
+      - '2.0'
+      - '2.1'
+    cisuPerimeterVersions:
+      - '1.9'
+    smurPerimeterVersions:
+      - '1.7'
+    gpsPerimeterVersions:
+      - '2.0'
+    sasPerimeterVersions:
+      - '1.0'
+    lrm_test: false
+  - client_id: fr.health.samuV1
+    common_name: fr.health.samuV1
+    perimeters:
+      - name: '15-15'
+        versions:
+          - '1.5'
+      - name: '15-smur'
+        versions:
+          - '1.7'
+      - name: '15-nexsis'
+        versions:
+          - '1.9'
+      - name: '15-gps'
+        versions:
+          - '2.0'
+      - name: '15-sas'
+        versions:
+          - '1.0'
+    editor: default-editor
     inhibitedUseCases:
       - 'ResourcesInfoCisuWrapper'
-  - client_id: fr.health.test.samu-v3
-    common_name: fr.health.test.samu-v3.fr
+    lrmPerimeterVersions:
+      - '1.5'
+    cisuPerimeterVersions:
+      - '1.9'
+    smurPerimeterVersions:
+      - '1.7'
+    gpsPerimeterVersions:
+      - '2.0'
+    sasPerimeterVersions:
+      - '1.0'
+    lrm_test: false
+  - client_id: fr.health.samuV2
+    common_name: fr.health.samuV2
+    perimeters:
+      - name: '15-15'
+        versions:
+          - '2.0'
+      - name: '15-smur'
+        versions:
+          - '1.7'
+      - name: '15-nexsis'
+        versions:
+          - '1.9'
+      - name: '15-gps'
+        versions:
+          - '2.0'
+      - name: '15-sas'
+        versions:
+          - '1.0'
+    editor: default-editor
+    lrmPerimeterVersions:
+      - '2.0'
+    cisuPerimeterVersions:
+      - '1.9'
+    smurPerimeterVersions:
+      - '1.7'
+    gpsPerimeterVersions:
+      - '2.0'
+    sasPerimeterVersions:
+      - '1.0'
+    lrm_test: false
+  - client_id: fr.health.samuV3
+    common_name: fr.health.samuV3
     perimeters:
       - name: '15-15'
         versions:
           - '2.1'
-    editor: ANS
-  - client_id: fr.health.test.samu-v3-direct-cisu
-    common_name: fr.health.test.samu-v3-direct-cisu.fr
-    perimeters:
-      - name: '15-15'
+      - name: '15-smur'
         versions:
-          - '2.1'
+          - '1.7'
       - name: '15-nexsis'
         versions:
           - '1.9'
-    editor: ANS
-    directCisu: true
-  - client_id: fr.fire.nxsis.sdisZ
-    common_name: fr.fire.nexsis.sdisZ.fr
-    perimeters:
-      - name: '15-nexsis'
+      - name: '15-gps'
         versions:
-          - '1.9'
-    editor: ANS
+          - '2.0'
+      - name: '15-sas'
+        versions:
+          - '1.0'
+    editor: default-editor
+    lrmPerimeterVersions:
+      - '2.1'
+    cisuPerimeterVersions:
+      - '1.9'
+    smurPerimeterVersions:
+      - '1.7'
+    gpsPerimeterVersions:
+      - '2.0'
+    sasPerimeterVersions:
+      - '1.0'
+    lrm_test: false


### PR DESCRIPTION
## 🔎 Détails

- suppression du csv loader dans HubConfiguration
- suppression des maps de conf éclatées
- migration vers les ClientProperties de la ClientPropertiesRegistry
- pour limiter la refacto, la ClientPropertiesRegistry est migrée dans HubConfiguration (hubConfig.getClientVersionsForPerimeter devient hubConfig.getClientPropertiesRegistry().getClientVersionsForPerimeter, même signature).

Ce ne peut être qu'un état transitoire (on préfèrerait gérer la ClientPropertiesRegistry comme un Bean accessible en direct) mais cela évite de trop modifier la classe ConversionUtils


## 🔗Ticket associé

[2. [ Dispatcher ] appeler directement la map de config client plutôt que les maps intermédiaires](https://app.asana.com/1/1201445755223134/project/1214912630771690/task/1215323679305302)
